### PR TITLE
Removes unused imports

### DIFF
--- a/src/ConnectorRunner.ts
+++ b/src/ConnectorRunner.ts
@@ -7,7 +7,6 @@
  */
 
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 import { assert, BentleyStatus, Guid, GuidString, Id64String, IModelStatus, Logger } from "@bentley/bentleyjs-core";
 /** @packageDocumentation

--- a/src/ITwinConnector.ts
+++ b/src/ITwinConnector.ts
@@ -6,13 +6,12 @@
  * @module Framework
  */
 import * as fs from "fs";
-import { assert, BentleyStatus, ClientRequestContext, IModelStatus, Logger } from "@bentley/bentleyjs-core";
+import { assert, BentleyStatus, ClientRequestContext, Logger } from "@bentley/bentleyjs-core";
 import { Subject } from "@bentley/imodeljs-backend";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
 import { ConnectorJobDefArgs } from "./ConnectorRunner";
 import { Synchronizer } from "./Synchronizer";
 import { ConnectorIssueReporter } from "./ConnectorIssueReporter";
-import { IModelError } from "@bentley/imodeljs-common";
 
 /** Abstract implementation of the iTwin Connector.
  * @beta

--- a/src/test/standalone/ITwinConnectorFwkStandAlone.test.ts
+++ b/src/test/standalone/ITwinConnectorFwkStandAlone.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import * as fs from "fs";
 import { IModelJsFs, SnapshotDb } from "@bentley/imodeljs-backend";
-import { Logger, BentleyStatus } from "@bentley/bentleyjs-core";
+import { BentleyStatus } from "@bentley/bentleyjs-core";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { ConnectorJobDefArgs, ConnectorRunner } from "../../ConnectorRunner";
 import { SqliteIssueReporter } from "../../SqliteIssueReporter";


### PR DESCRIPTION
Removes all unused imports. Added linting checks need to be added to the build pipeline to prevent these issues from arising.