### PR TITLE
new connector onFinish callback

### DIFF
--- a/src/BaseConnector.ts
+++ b/src/BaseConnector.ts
@@ -8,6 +8,7 @@ import type { Subject } from "@itwin/core-backend";
 import type { ConnectorIssueReporter } from "./ConnectorIssueReporter";
 import type { Synchronizer } from "./Synchronizer";
 import * as fs from "fs";
+import * as path from "path";
 
 /** Abstract implementation of the iTwin Connector.
  * @beta
@@ -17,6 +18,8 @@ export abstract class BaseConnector {
   private _synchronizer?: Synchronizer;
   private _jobSubject?: Subject;
   private _issueReporter?: ConnectorIssueReporter;
+  
+  public onFinish?: () => void;
 
   public static async create(): Promise<BaseConnector> {
     throw new Error("BaseConnector.create() is not implemented!");
@@ -66,7 +69,7 @@ export abstract class BaseConnector {
       canUserFix,
     };
     Logger.logError("itwin-connector.Framework", `Attempting to write file to ${dir}`);
-    fs.writeFileSync(`${dir}\\SyncError.json`, JSON.stringify(object), {flag: "w"});
+    fs.writeFileSync(path.join(dir, "SyncError.json"), JSON.stringify(object), {flag: "w"});
   }
 
   /**

--- a/src/BaseConnector.ts
+++ b/src/BaseConnector.ts
@@ -19,8 +19,6 @@ export abstract class BaseConnector {
   private _jobSubject?: Subject;
   private _issueReporter?: ConnectorIssueReporter;
   
-  public onFinish?: () => void;
-
   public static async create(): Promise<BaseConnector> {
     throw new Error("BaseConnector.create() is not implemented!");
   }
@@ -29,6 +27,11 @@ export abstract class BaseConnector {
   public async onOpenIModel(): Promise<BentleyStatus> {
     return BentleyStatus.SUCCESS;
   }
+
+  /** This is called when the synchronization is finished, just before the iModel is closed. The connector can implement this callback if its needs
+   * to close the source file or do any other post-synchronization clean-up. The connector should *not* attempt to write to the iModel.
+   */
+  public onClosingIModel?: () => void;
 
   /** This is only called the first time this source data is synchronized.  Allows the connector to perform any steps after the Job Subject has been created.  It
    * must call synchronizer.recordDocument on the source data. Called in the [Repository channel]($docs/learning/backend/Channel).

--- a/src/ConnectorRunner.ts
+++ b/src/ConnectorRunner.ts
@@ -291,8 +291,7 @@ export class ConnectorRunner {
     if (this._db) {
       this._db.abandonChanges();
 
-      if (this._connector !== undefined && this.connector.onFinish !== undefined)
-        this.connector.onFinish();
+      this.connector?.onClosingIModel?.();
 
       this._db.close();
     }

--- a/src/ConnectorRunner.ts
+++ b/src/ConnectorRunner.ts
@@ -278,10 +278,10 @@ export class ConnectorRunner {
   public recordError(err: any) {
     const errorFile = this.jobArgs.errorFile;
     const errorStr = JSON.stringify({
-      id: this._connector?.getConnectorName(),
+      id: this._connector?.getConnectorName() ?? "",
       message: "Failure",
       description: err.message,
-      extendedData: {},
+      extendedData: err,
     });
     fs.writeFileSync(errorFile, errorStr);
     Logger.logInfo(LoggerCategories.Framework, `Error recorded at ${errorFile}`);
@@ -290,6 +290,10 @@ export class ConnectorRunner {
   private async onFinish() {
     if (this._db) {
       this._db.abandonChanges();
+
+      if (this._connector !== undefined && this.connector.onFinish !== undefined)
+        this.connector.onFinish();
+
       this._db.close();
     }
 


### PR DESCRIPTION
also made a portability fix
also added the error itself as the extended data in error.json - in the two-process (IPC) connector scenario, the error itself has detailed information, including nested exceptions, that describe the origin of the problem