### PR TITLE
ADO# 1334078 - Revert ScopeToPartition logic back to Channel based deletion detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itwin/connector-framework",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itwin/connector-framework",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/connector-framework",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "iTwin Connector Framework",
   "main": "lib/src/connector-framework.js",
   "typings": "lib/src/connector-framework.d.ts",

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -657,6 +657,24 @@ export class Synchronizer {
 
         const element = this.imodel.elements.getElement(elementId);
         const hasSeenElement = this._seenElements.has(elementId);
+        // NEEDSWORK ADO# 1334078
+        // We need to exclude functional elements created for aggregation
+        // The aggregation work flow related elements in functional models 
+        // to elements in the aggregation functional model using XSAs
+        // This requires special treatment for these specific functional elements
+        // How to identify these special functional elements
+        // 1) they will have XSA to elements in the app's functional model
+        // 2) There are also relationships from either 
+        // elements in PhysicalModels (StagingAreaPhysicalElementFulfillsFunction) or
+        // DrawingModels (PhysicalElementFulfillsFunction)
+        // 3) In CMAP it is called "Project Digital Twin Functional Model", 
+        // it would be good to know if there is a special schema sub class for these
+        // elements/models, then we could simply use the class name as a filter.
+        // After reviewing the ProcessFunctional schema, it appears that
+        // there are no special subclasses for the FunctionalModels or 
+        // FunctionalElements used for Aggregation
+
+
         if (!hasSeenElement) {
           if (element instanceof DefinitionElement)
             defElementsToDelete.push(elementId);

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -583,6 +583,12 @@ export class Synchronizer {
       // Note: channel based deletion detection is required for models
       // that are scoped to partion because xsas for aggregation elements in plantsight
       // are also scoped to partition and we don't want to delete them.
+    if (this._ddp.scopeToPartition == true) {
+      const logMessage = `Channel based deletion detection is required for models that are scoped to partition. Performing channel-based deletion detection!`;
+      Logger.logInfo(LoggerCategories.Framework, logMessage);
+      }
+
+
       this.detectDeletedElementsInChannel();
     }
     else      

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -583,13 +583,10 @@ export class Synchronizer {
       // Note: channel based deletion detection is required for models
       // that are scoped to partion because xsas for aggregation elements in plantsight
       // are also scoped to partition and we don't want to delete them.
-    if (this._ddp.scopeToPartition == true) {
-      const logMessage = `Channel based deletion detection is required for models that are scoped to partition. Performing channel-based deletion detection!`;
-      Logger.logInfo(LoggerCategories.Framework, logMessage);
-      }
+    if (this._ddp.scopeToPartition)
+        Logger.logInfo(LoggerCategories.Framework, `Channel based deletion detection is required for models that are scoped to partition. Performing channel-based deletion detection!`);
 
-
-      this.detectDeletedElementsInChannel();
+    this.detectDeletedElementsInChannel();
     }
     else      
     {

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -577,9 +577,7 @@ export class Synchronizer {
     if (this.imodel.isSnapshotDb())
       return;
 
-    if (this._ddp.fileBased && !this._ddp.scopeToPartition)
-      this.detectDeletedElementsInFiles();
-    else
+    if (!this._ddp.fileBased || this._ddp.scopeToPartition)
     {
       // ADO# 1334078
       // Note: channel based deletion detection is required for models
@@ -587,7 +585,10 @@ export class Synchronizer {
       // are also scoped to partition and we don't want to delete them.
       this.detectDeletedElementsInChannel();
     }
-      
+    else      
+    {
+      this.detectDeletedElementsInFiles();
+    }
   }
 
   /** Detect and delete all elements and models that meet the following conditions:
@@ -618,35 +619,13 @@ export class Synchronizer {
     });
   }
 
-  // given a repository link, return a model id using ElementHasLinks relationship
-  private getScopeID(_repLinkId: Id64String): Id64String {
-    const sql = `select ehl.SourceECInstanceId from bis.ElementHasLinks ehl where ehl.TargetECInstanceId=?`;
-
-    let scopeId: Id64String = "";
-    this.imodel.withPreparedStatement(sql, (statement: ECSqlStatement): void => {
-      statement.bindId(1, _repLinkId);
-      if (DbResult.BE_SQLITE_ROW === statement.step()) {
-        const val = statement.getValue(0);
-        scopeId = val.getId();
-      }
-    });
-
-    return scopeId;
-  }
-
   private detectDeletedElementsInFiles() {
     for (const value of this._links.values()) {
       if (value.itemState === ItemState.Unchanged || value.itemState === ItemState.New)
         continue;
       assert(value.elementProps.id !== undefined && Id64.isValidId64(value.elementProps.id));
 
-      let scopeId = value.elementProps.id;
-
-      if (this._ddp.scopeToPartition) {
-        scopeId = this.getScopeID(value.elementProps.id);
-      }
-
-      this.detectDeletedElementsInScope(scopeId);
+      this.detectDeletedElementsInScope(value.elementProps.id);
     }
   }
 

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -577,10 +577,17 @@ export class Synchronizer {
     if (this.imodel.isSnapshotDb())
       return;
 
-    if (this._ddp.fileBased)
+    if (this._ddp.fileBased && !this._ddp.scopeToPartition)
       this.detectDeletedElementsInFiles();
     else
+    {
+      // ADO# 1334078
+      // Note: channel based deletion detection is required for models
+      // that are scoped to partion because xsas for aggregation elements in plantsight
+      // are also scoped to partition and we don't want to delete them.
       this.detectDeletedElementsInChannel();
+    }
+      
   }
 
   /** Detect and delete all elements and models that meet the following conditions:
@@ -657,23 +664,6 @@ export class Synchronizer {
 
         const element = this.imodel.elements.getElement(elementId);
         const hasSeenElement = this._seenElements.has(elementId);
-        // NEEDSWORK ADO# 1334078
-        // We need to exclude functional elements created for aggregation
-        // The aggregation work flow related elements in functional models 
-        // to elements in the aggregation functional model using XSAs
-        // This requires special treatment for these specific functional elements
-        // How to identify these special functional elements
-        // 1) they will have XSA to elements in the app's functional model
-        // 2) There are also relationships from either 
-        // elements in PhysicalModels (StagingAreaPhysicalElementFulfillsFunction) or
-        // DrawingModels (PhysicalElementFulfillsFunction)
-        // 3) In CMAP it is called "Project Digital Twin Functional Model", 
-        // it would be good to know if there is a special schema sub class for these
-        // elements/models, then we could simply use the class name as a filter.
-        // After reviewing the ProcessFunctional schema, it appears that
-        // there are no special subclasses for the FunctionalModels or 
-        // FunctionalElements used for Aggregation
-
 
         if (!hasSeenElement) {
           if (element instanceof DefinitionElement)


### PR DESCRIPTION
There was an earlier change to accommodate existing connectors which were scoped to partition (which is considered to be incorrect, but, unfortunately done in the test connector).  Subsequent to this change, it was discovered that the aggregation workflow in PlantSight ALSO scoped their aggregation (functional) elements to the functional model using external source aspects (a similarly dubious use of external source aspects).  Therefore, undesired elements would be detected and deleted.  The fix would be to test that the elements were also under this connector's job subject which is, in effect, channel based deletion detection.  Therefore, when file based is true and scopeToPartition is true, we revert the logic back to channel based deletion detection.  On one hand it may seem like the added scopeToPartiton property is useless, but, it may be of value down the road if we ever decide to discontinue channel based support.  scopeToPartition could be used to identify affected connectors and add warnings to log messages.