### PR TITLE
Tag_Docs job - An image label with the label Ubuntu16 does not exist.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,3 +204,11 @@ stages:
         type: "Build"
         tags: "hasDocs"
         condition: and(contains(variables['Build.SourceVersionMessage'], '[publish docs]'), not(contains(variables['Build.SourceVersionMessage'], '(dev)')))
+     strategy:
+       matrix:
+         linux:
+           imageName: 'ubuntu-latest'
+         windows:
+           imageName: 'windows-latest'
+     pool:
+       vmImage: '$(imageName)'


### PR DESCRIPTION
issue:

Pipelines - Run 20240426.1 logs (azure.com)

##[warning]An image label with the label Ubuntu16 does not exist.  ,##[error]The remote provider was unable to process the request.  Pool: Azure Pipelines 

Attempt to fix by specifying which image to use.