### PR TITLE
Improve setup and teardown of integration tests w.r.t. creating and deleting of iModels

### DIFF
--- a/test/integration/ConnectorRunner.test.ts
+++ b/test/integration/ConnectorRunner.test.ts
@@ -16,13 +16,15 @@ import { IModelsClient } from "@itwin/imodels-client-authoring";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import * as utils from "../ConnectorTestUtils";
 import * as path from "path";
+import { TestIModelManager } from "./TestIModelManager";
 
 describe("iTwin Connector Fwk (#integration)", () => {
 
   let testProjectId: Id64String;
-  let testIModelId: Id64String| undefined;
-  let updateIModelId: Id64String | undefined;
-  let unmapIModelId: Id64String | undefined;
+  let newImodelName = process.env.test_new_imodel_name ? process.env.test_new_imodel_name : "ConnectorFramework";
+  let updateImodelName = process.env.test_existing_imodel_name? process.env.test_existing_imodel_name: newImodelName + "Update";
+  let unmapImodelName = process.env.test_unmap_imodel_name? process.env.test_unmap_imodel_name: newImodelName + "Unmap";
+  
   let testClientConfig: TestBrowserAuthorizationClientConfiguration;
   let token: AccessToken| undefined;
 
@@ -56,25 +58,6 @@ describe("iTwin Connector Fwk (#integration)", () => {
     }
     IModelHost.authorizationClient = client;
     testProjectId = process.env.test_project_id!;
-    let newImodelName = process.env.test_new_imodel_name ? process.env.test_new_imodel_name : "ConnectorFramework";
-    let updateImodelName = process.env.test_existing_imodel_name? process.env.test_existing_imodel_name: newImodelName + "Update";
-
-
-    updateIModelId = await IModelHost.hubAccess.queryIModelByName({ accessToken: token, iTwinId: testProjectId, iModelName: updateImodelName });
-    if (!updateIModelId) {
-      updateIModelId = await IModelHost.hubAccess.createNewIModel({ iTwinId: testProjectId, iModelName: updateImodelName, accessToken: token });
-    }
-
-    testIModelId = await IModelHost.hubAccess.queryIModelByName({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName});
-    if (!testIModelId) {
-      testIModelId = await IModelHost.hubAccess.createNewIModel({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName });
-    }
-
-    // TODO: change hardcoded iModel name
-    unmapIModelId = await IModelHost.hubAccess.queryIModelByName({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName + "Unmap"});
-    if (!unmapIModelId) {
-      unmapIModelId = await IModelHost.hubAccess.createNewIModel({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName + "Unmap" });
-    }
   });
 
   after(async () => {
@@ -121,6 +104,11 @@ describe("iTwin Connector Fwk (#integration)", () => {
   }
 
   it("should download and perform updates on a new imodel", async () => {
+    if (token === undefined)
+      throw new Error (`Can't create a test iModel without a token!`);
+
+    const iModelMgr: TestIModelManager = new TestIModelManager (testProjectId, newImodelName);
+
     const assetPath = path.join(KnownTestLocations.assetsDir, "TestConnector.json");
     const jobArgs = new JobArgs({
       source: assetPath,
@@ -130,7 +118,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
 
     const hubArgs = new HubArgs({
       projectGuid: testProjectId,
-      iModelGuid: testIModelId,
+      iModelGuid: await iModelMgr.createIModel(token),
     } as HubArgsProps);
 
     hubArgs.clientConfig = testClientConfig;
@@ -141,11 +129,14 @@ describe("iTwin Connector Fwk (#integration)", () => {
     await runConnector(jobArgs, hubArgs);
 
     // cleanup
-    await IModelHost.hubAccess.deleteIModel({accessToken: token, iTwinId: testProjectId, iModelId: testIModelId! });
+    await iModelMgr.deleteIModel(token);
   });
 
   it("should download and perform updates on an existing imodel", async () => {
-    // TODO: This test does not seem to operate on a fresh iModel; see before().
+    if (token === undefined)
+      throw new Error (`Can't create a test iModel without a token!`);
+
+    const iModelMgr: TestIModelManager = new TestIModelManager (testProjectId, updateImodelName);
 
     const assetPath = path.join(KnownTestLocations.assetsDir, "TestConnector.json");
     const jobArgs = new JobArgs({
@@ -156,7 +147,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
 
     const hubArgs = new HubArgs({
       projectGuid: testProjectId,
-      iModelGuid: updateIModelId,
+      iModelGuid: await iModelMgr.createIModel(token),
     } as HubArgsProps);
 
     hubArgs.clientConfig = testClientConfig;
@@ -170,11 +161,15 @@ describe("iTwin Connector Fwk (#integration)", () => {
     await runConnector(jobArgs, hubArgs);
 
     // cleanup
-    await IModelHost.hubAccess.deleteIModel({accessToken: token, iTwinId: testProjectId, iModelId: updateIModelId!});
+    await iModelMgr.deleteIModel(token);
   });
 
   it("should download and perform an unmap operation on an existing imodel", async () => {
-    // TODO: This test does not seem to operate on a fresh iModel; see before().
+
+    if (token === undefined)
+      throw new Error (`Can't create a test iModel without a token!`);
+
+    const iModelMgr: TestIModelManager = new TestIModelManager (testProjectId, unmapImodelName);
 
     const assetPath = path.join(KnownTestLocations.assetsDir, "TestConnector.json");
     const jobArgs = new JobArgs({
@@ -185,7 +180,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
 
     const hubArgs = new HubArgs({
       projectGuid: testProjectId,
-      iModelGuid: unmapIModelId,
+      iModelGuid: await iModelMgr.createIModel(token),
     } as HubArgsProps);
 
     hubArgs.clientConfig = testClientConfig;
@@ -209,6 +204,6 @@ describe("iTwin Connector Fwk (#integration)", () => {
     await verifyIModel(jobArgs, hubArgs);
 
     // cleanup
-    await IModelHost.hubAccess.deleteIModel({accessToken: token, iTwinId: testProjectId, iModelId: unmapIModelId!});
+    await iModelMgr.deleteIModel(token);
   });
 });

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -45,16 +45,30 @@ export class TestIModelManager {
         return this._modelIdCreated;
     }
 
+/** @method
+ * @name createIModel 
+ * @param accessToken
+ * @param iTwinId
+ * @param iModelId
+ * @returns model id that was either found or created */
+    async tryDeleteIModel (accessToken: AccessToken, iTwinId: string, iModelId: string) {
+        try {
+            await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: iTwinId, iModelId: iModelId});
+        }
+        catch {
+            throw new Error (`Exception thrown while attempting to delete iModel id ${iModelId} from iTwin id ${iTwinId} - check user has sufficient privileges to delete an iModel!`);
+        }
+    }
  /** @method
  * @name deleteIModel  
  * @param accessToken */ 
     async deleteIModel (accessToken: AccessToken) {
         if (this._modelIdCreated)
-            await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: this._iTwinId, iModelId: this._modelIdCreated});
+            await this.tryDeleteIModel(accessToken, this._iTwinId, this._modelIdCreated);
 
         if (this._deleteExistingModels) {
             this._existingModels.forEach (async model => {
-                await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: this._iTwinId, iModelId: model});
+                await this.tryDeleteIModel(accessToken, this._iTwinId, model);
             });
         }
 

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -33,7 +33,7 @@ export class TestIModelManager {
         while (foundIModelId) {
             this._existingModels.push (foundIModelId);
             ++i;
-            currName = this._iModelName + i;
+            currName = `${this._iModelName}${i}`;
             foundIModelId = await IModelHost.hubAccess.queryIModelByName({ iTwinId: this._iTwinId, iModelName: currName});
         }
 

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -46,7 +46,7 @@ export class TestIModelManager {
     }
 
 /** @method
- * @name createIModel 
+ * @name tryDeleteIModel 
  * @param accessToken
  * @param iTwinId
  * @param iModelId

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -4,11 +4,22 @@ import { IModelHost } from "@itwin/core-backend";
 export class TestIModelManager {
     private _existingModels : string[];
     private _modelIdCreated?: string;
-
-    constructor (private _iTwinId : string, private _iModelName: string, private _reuseExistingModel = false , private _deleteExistingModels = true) {
+/**
+ * @class TestIModelManager
+ * @param _iTwinId 
+ * @param _iModelName 
+ * @param [_reuseExistingModel=false] 
+ * @param [_deleteExistingModels=true] 
+ * @classdesc Helps with creating/finding and deleting of iModels.
+ */
+    constructor (private _iTwinId : string, private _iModelName: string, private _reuseExistingModel: boolean = false , private _deleteExistingModels: boolean = true) {
     this._existingModels = [];
     }
-
+/** @method
+ * @name createIModel 
+ * @param accessToken
+ * @returns model id that was either found or created
+ * */
     async createIModel (accessToken: AccessToken) : Promise<string> {
         let currName : string = this._iModelName;
         let foundIModelId : string|undefined = await IModelHost.hubAccess.queryIModelByName({ iTwinId: this._iTwinId, iModelName: currName});
@@ -34,6 +45,9 @@ export class TestIModelManager {
         return this._modelIdCreated;
     }
 
+ /** @method
+ * @name deleteIModel  
+ * @param accessToken */ 
     async deleteIModel (accessToken: AccessToken) {
         if (this._modelIdCreated)
             await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: this._iTwinId, iModelId: this._modelIdCreated});

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -1,0 +1,48 @@
+import type { AccessToken} from "@itwin/core-bentley";
+import { IModelHost } from "@itwin/core-backend";
+
+export class TestIModelManager {
+    private _existingModels : string[];
+    private _modelIdCreated?: string;
+
+    constructor (private _iTwinId : string, private _iModelName: string, private _reuseExistingModel = false , private _deleteExistingModels = true) {
+    this._existingModels = [];
+    }
+
+    async createIModel (accessToken: AccessToken) : Promise<string> {
+        let currName : string = this._iModelName;
+        let foundIModelId : string|undefined = await IModelHost.hubAccess.queryIModelByName({ iTwinId: this._iTwinId, iModelName: currName});
+        let i : number = 0;
+        
+        if (this._reuseExistingModel && foundIModelId) {
+            this._existingModels.push (foundIModelId);
+            return foundIModelId;
+        }
+
+        while (foundIModelId) {
+            this._existingModels.push (foundIModelId);
+            ++i;
+            currName = this._iModelName + i;
+            foundIModelId = await IModelHost.hubAccess.queryIModelByName({ iTwinId: this._iTwinId, iModelName: currName});
+        }
+
+        this._modelIdCreated = await IModelHost.hubAccess.createNewIModel({ accessToken: accessToken, iTwinId: this._iTwinId, iModelName: currName });
+
+        if (this._modelIdCreated === undefined)
+            throw new Error (`Failed to create a new model named ${currName} in iTwin (project) ${this._iTwinId}`);
+
+        return this._modelIdCreated;
+    }
+
+    async deleteIModel (accessToken: AccessToken) {
+        if (this._modelIdCreated)
+            await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: this._iTwinId, iModelId: this._modelIdCreated});
+
+        if (this._deleteExistingModels) {
+            this._existingModels.forEach (async model => {
+                await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: this._iTwinId, iModelId: model});
+            });
+        }
+
+    }
+}

--- a/test/integration/TestIModelManager.ts
+++ b/test/integration/TestIModelManager.ts
@@ -51,7 +51,7 @@ export class TestIModelManager {
  * @param iTwinId
  * @param iModelId
  * @returns model id that was either found or created */
-    async tryDeleteIModel (accessToken: AccessToken, iTwinId: string, iModelId: string) {
+    private async tryDeleteIModel (accessToken: AccessToken, iTwinId: string, iModelId: string) {
         try {
             await IModelHost.hubAccess.deleteIModel({accessToken: accessToken, iTwinId: iTwinId, iModelId: iModelId});
         }


### PR DESCRIPTION
This is intended to address several issues that caused integration tests to fail even when state of source code was good (tests should have succeeded - no regressions present).
ref. ADO# 1404585, 1402128
, 1402129

1. If the model name for a testcase was found, that model would be re-used even though some tests will fail if the model is reused.
2. if the test user didn't have sufficient permissions e.g. regular user vs. project manager, they would be able to create a model but not delete that same model.  This would give some vague error and create subsequent failing tests.
3. All of the testcases were created in the beginning and were deleted one by one as tests were run.  That would present problems in two scenarios:
a. Having an unexpected stop that left a model behind after tests were run could screw up the counts in a subsequent run.
b. Running one of the integration tests would ensure all tests got created, but, only the testcase(s) used for the test(s) that were run were deleted and all the other models are left behind.

**The following fixes were made to address the above issue**s:
1. Created a new class TestIModelManager that...
Will not reuse existing models by default therefore it will try "model", "model1", "model2", ... until an unused model name is found.
Should there be existing models, those will be deleted by default after the test is run.

2. The ConnectorRunner.test.ts was changed to implement the new TestIModelManager in each of the three integration tests.  The iModels are created at the beginning of the test and deleted at the end of the test.

