### PR TITLE
bf: ADO# 1051429 - remove call to deprecated method IModelDb.Views.se…

### DIFF
--- a/test/TestConnector/TestConnector.ts
+++ b/test/TestConnector/TestConnector.ts
@@ -163,7 +163,7 @@ export default class TestConnector extends BaseConnector {
 
     this.convertGroupElements(groupModelId);
     this.convertPhysicalElements(physicalModelId, definitionModelId, groupModelId);
-    this.synchronizer.imodel.views.setDefaultViewId(this.createView(definitionModelId, physicalModelId, "TestConnectorView"));
+    this.createView(definitionModelId, physicalModelId, "TestConnectorView");
   }
   // __PUBLISH_EXTRACT_END__
 


### PR DESCRIPTION
This was filed approximately 1.5 years ago, but the API used to set the default view id (IModelDB.ViewssetDefaultViewId) was deprecated ref. [setDefaultViewId - core-backend (itwinjs.org)](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/imodeldb.views/setdefaultviewid/#badge-textdeprecated-in-42x-avoid-setting-this-property--it-is-not-practical-for-one-single-view-to-serve-the-needs-of-the-many-applications).  The TestConnector still calls this deprecated method.  I removed this method and tested it.  The behavior in DesignReview was also changed to be much more user friendly.  It now reports "No saved views were found, switching you to the 3D models tab" resulting in a much less harsh user experience.  So, I'll simply delete the deprecated method.

![NoSavedViews](https://github.com/iTwin/connector-framework/assets/66284944/e54453b0-7d37-4610-90fc-aee4e5ea4d9b)
