### PR TITLE
Move iTwinjs core dependencies ahead to 4.7 and bump up CF version number from 2.1.x to 2.2.0-dev.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
         displayName: 'Install Node.js'
 
       - script: |
-          npm install
+          npm install --legacy-peer-deps 
         displayName: 'install packages'
 
       # - script: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,43 @@
 {
   "name": "@itwin/connector-framework",
-  "version": "2.1.0",
+  "version": "2.2.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itwin/connector-framework",
-      "version": "2.1.0",
+      "version": "2.2.0-dev.1",
       "license": "MIT",
       "dependencies": {
-        "@itwin/core-backend": "^4.6.0",
-        "cross-env": "^7.0.3"
+        "@itwin/core-backend": "^4.7.0-dev.15",
+        "cross-env": "^7.0.3",
+        "typedoc": "^0.25.13"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@itwin/build-tools": "^4.6.0",
-        "@itwin/core-bentley": "^4.6.0",
-        "@itwin/core-common": "^4.6.0",
-        "@itwin/core-geometry": "^4.6.0",
-        "@itwin/core-quantity": "^4.6.0",
-        "@itwin/ecschema-metadata": "^4.6.0",
+        "@itwin/build-tools": "^4.7.0-dev.15",
+        "@itwin/core-bentley": "^4.7.0-dev.15",
+        "@itwin/core-common": "^4.7.0-dev.15",
+        "@itwin/core-geometry": "^4.7.0-dev.15",
+        "@itwin/core-quantity": "^4.7.0-dev.15",
+        "@itwin/ecschema-metadata": "^4.7.0-dev.15",
         "@itwin/eslint-plugin": "^4.0.2",
-        "@itwin/imodels-access-backend": "^5.0.4",
-        "@itwin/imodels-client-authoring": "^5.3.1",
+        "@itwin/imodels-access-backend": "^5.1.1",
+        "@itwin/imodels-client-authoring": "^5.5.0",
         "@itwin/node-cli-authorization": "^2.0.2",
         "@itwin/oidc-signin-tool": "^4.3.5",
-        "@types/chai": "^4.1.4",
+        "@types/chai": "4.3.1",
         "@types/chai-as-promised": "^7",
-        "@types/mocha": "^8.2.2",
-        "@types/node": "^14.0.0",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "~18.16.20",
         "@types/object-hash": "^1.3.0",
         "@types/request-promise-native": "^1.0.17",
         "@types/ws": "^8.5.3",
-        "chai": "^4.1.2",
+        "chai": "^4.3.10",
         "chai-as-promised": "^7",
         "cpx2": "^3.0.0",
         "dotenv": "10.0.0",
-        "eslint": "^8.44.0",
+        "eslint": "^8.56.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.1",
         "mocha": "^10.2.0",
@@ -47,14 +48,14 @@
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.21",
         "ts-node": "10.8.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.3.3"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.6.0",
-        "@itwin/core-common": "^4.6.0",
+        "@itwin/core-bentley": "^4.7.0-dev.15",
+        "@itwin/core-common": "^4.7.0-dev.15",
         "@itwin/node-cli-authorization": "^2.0.1"
       }
     },
@@ -104,6 +105,48 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@azure/core-client": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.9.1",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/@azure/core-tracing": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@azure/core-http": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.4.tgz",
@@ -126,6 +169,32 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz",
+      "integrity": "sha512-5MnV1yqzZwgNLLjlizsU3QqOeQChkIXw781Fwh1xdAqJR5AA32IUaq6xv1BICJvfbHoa+JYcaij2HFkhLbNTJQ==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-http/node_modules/form-data": {
@@ -166,6 +235,49 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+      "integrity": "sha512-CeuTvsXxCUmEuxH5g/aceuSl6w2EugvNHKAtKKVdiX915EjJJxAwfzNNWZreNnbxHZ2fi0zaM6wwS23x2JVqSQ==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.9.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@azure/core-tracing": {
       "version": "1.0.0-preview.13",
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
@@ -179,15 +291,39 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+      "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.4.2.tgz",
+      "integrity": "sha512-CW3MZhApe/S4iikbYKE7s83fjDBPIr2kpidX+hlGRwh7N4o1nIpQ/PfJTeioqhfqdMvRtheEl+ft64fyTaLNaA==",
+      "dev": true,
+      "dependencies": {
+        "fast-xml-parser": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -202,22 +338,39 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.18.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.18.0.tgz",
-      "integrity": "sha512-BzBZJobMoDyjJsPRMLNHvqHycTGrT8R/dtcTx9qUFcqwSRfGVK9A/cZ7Nx38UQydT9usZGbaDCN75QRNjezSAA==",
+      "version": "12.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.23.0.tgz",
+      "integrity": "sha512-c1KJ5R5hqR/HtvmFtTn/Y1BNMq45NUBp0LZH7yF8WFMET+wmESgEr0FVTu/Z5NonmfUjbgJZG5Nh8xHc5RdWGQ==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-http": "^3.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-client": "^1.6.2",
+        "@azure/core-http-compat": "^2.0.0",
         "@azure/core-lro": "^2.2.0",
         "@azure/core-paging": "^1.1.1",
-        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-rest-pipeline": "^1.10.1",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/core-xml": "^1.3.2",
         "@azure/logger": "^1.0.0",
         "events": "^3.0.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob/node_modules/@azure/core-tracing": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -879,9 +1032,9 @@
       }
     },
     "node_modules/@bentley/imodeljs-native": {
-      "version": "4.6.31",
-      "resolved": "https://registry.npmjs.org/@bentley/imodeljs-native/-/imodeljs-native-4.6.31.tgz",
-      "integrity": "sha512-4a90NkABprmae6irSv+a3lWFYTeYy0zS/9iEmQ4bmOZ9StbyLSbrvpDa7xgqvqHJkpZAW7YLpO+5nC1x4Ly2xQ==",
+      "version": "4.7.20",
+      "resolved": "https://registry.npmjs.org/@bentley/imodeljs-native/-/imodeljs-native-4.7.20.tgz",
+      "integrity": "sha512-TZGzuAH/ocw/EI/37Eu4Dl8ny/QLlQHb5vbIgA1ndynjCI0X7UUS4ptYbJ2hZnzWRw5y9u5eZXZOZlFX3e0Xjg==",
       "hasInstallScript": true
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1189,9 +1342,9 @@
       }
     },
     "node_modules/@itwin/build-tools": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/build-tools/-/build-tools-4.6.0.tgz",
-      "integrity": "sha512-I73MIEoMzCf1KxZSQ3tq7RP13xqE6dTofki67x7jKkuKw3r/Xl7O0ni8nwzvvKGNb7lsshOM9PCpLbsYr8c/1g==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/build-tools/-/build-tools-4.7.0-dev.15.tgz",
+      "integrity": "sha512-wbU5F1xYexPbA9RoBxvu31ikgUpy8vtRgMSDbSGxgDOOw7UpkLWbyIOGVyILLZYgWDLt8NUy/e1U+CTqwWPjFw==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor": "~7.40.0",
@@ -1205,7 +1358,7 @@
         "rimraf": "^3.0.2",
         "tree-kill": "^1.2.2",
         "typedoc": "^0.25.8",
-        "typedoc-plugin-merge-modules": "^4.0.1",
+        "typedoc-plugin-merge-modules": "^5.1.0",
         "typescript": "~5.3.3",
         "wtfnode": "^0.9.1",
         "yargs": "^17.4.0"
@@ -1288,40 +1441,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@itwin/build-tools/node_modules/typedoc": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
-      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
-      "dev": true,
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
-      }
-    },
-    "node_modules/@itwin/build-tools/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@itwin/certa": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@itwin/certa/-/certa-4.3.3.tgz",
@@ -1364,13 +1483,13 @@
       }
     },
     "node_modules/@itwin/core-backend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-backend/-/core-backend-4.6.0.tgz",
-      "integrity": "sha512-UjUlFKlKK9qIvnrsereeCvJWfNaabudKnP73l9pFp4JU9J8dDjGrOQSalL1hX4MdAHJTtLmCaAbTQnbqf+f5wg==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-backend/-/core-backend-4.7.0-dev.15.tgz",
+      "integrity": "sha512-Rt7Gnfy6jsFk7Urj3ObMZnlNqGAanSD+cmjMVjm+HK7vLSlBSaMs69oyyAQYYUJLRnwNx7zps/z7BTPglGKeJg==",
       "dependencies": {
-        "@bentley/imodeljs-native": "4.6.31",
+        "@bentley/imodeljs-native": "4.7.20",
         "@itwin/cloud-agnostic-core": "^2.1.0",
-        "@itwin/core-telemetry": "4.6.0",
+        "@itwin/core-telemetry": "4.7.0-dev.15",
         "@itwin/object-storage-azure": "^2.2.2",
         "@itwin/object-storage-core": "^2.2.2",
         "form-data": "^2.5.1",
@@ -1387,9 +1506,9 @@
         "node": "^18.0.0 || ^20.0.0"
       },
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.6.0",
-        "@itwin/core-common": "^4.6.0",
-        "@itwin/core-geometry": "^4.6.0",
+        "@itwin/core-bentley": "^4.7.0-dev.15",
+        "@itwin/core-common": "^4.7.0-dev.15",
+        "@itwin/core-geometry": "^4.7.0-dev.15",
         "@opentelemetry/api": "^1.0.4"
       },
       "peerDependenciesMeta": {
@@ -1399,61 +1518,62 @@
       }
     },
     "node_modules/@itwin/core-bentley": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-4.6.0.tgz",
-      "integrity": "sha512-GXr9L6ThFdEGQKFSn+jEC5g2IbHDdg14EUHyb1HgVqYY6y1E9UPy7RARs4bC38xFOKXzEg/2dURas0qUWhDGDA=="
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-4.7.0-dev.15.tgz",
+      "integrity": "sha512-L0usFzyX1xr7jqhEwaXwtvHtoCMTpyk54TiyxvxtNoZyYLI51cazzK/8socxRiFnjIFgDQqO9ZcRN0F97GqQcA=="
     },
     "node_modules/@itwin/core-common": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.6.0.tgz",
-      "integrity": "sha512-QH9JMtZIj5bbx6gts8xBnXtNoM22r4AWUQrP6xd9Az1//HjfIGQKbTY7TDWalP2bGelI4l2D7qWeid9VZVlVHg==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.7.0-dev.15.tgz",
+      "integrity": "sha512-GQvScyEC0pI8MwFOa+cjrtUe4luWm5NZ0jBOtPSppX+mhL2j1DTUR2BP+Jw4YhI/kIsJcPIbtIUX83esOV6HHg==",
       "dependencies": {
         "flatbuffers": "~1.12.0",
         "js-base64": "^3.6.1"
       },
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.6.0",
-        "@itwin/core-geometry": "^4.6.0"
+        "@itwin/core-bentley": "^4.7.0-dev.15",
+        "@itwin/core-geometry": "^4.7.0-dev.15"
       }
     },
     "node_modules/@itwin/core-geometry": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-4.6.0.tgz",
-      "integrity": "sha512-dwlXp8fx8aUe+ipKDgRdyqPIQ62sldahyRkQCN4KsH9mF8Urn3IoYp92CgQh6LWI+pg5pY3tMrEHuP8aImtd5g==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-4.7.0-dev.15.tgz",
+      "integrity": "sha512-VxFGlLOxN83T6uQegQJzdWmF/4Yq4hm31sMGFp7ONxnDiQNO6hCiav6NpQLT+IlKhbTreaSmH433Lx10QO4EFQ==",
+      "dev": true,
       "dependencies": {
-        "@itwin/core-bentley": "4.6.0",
+        "@itwin/core-bentley": "4.7.0-dev.15",
         "flatbuffers": "~1.12.0"
       }
     },
     "node_modules/@itwin/core-quantity": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-quantity/-/core-quantity-4.6.0.tgz",
-      "integrity": "sha512-R7MRL38p/JqJw6YhjVoz0WcC06Jq1U+BUKwtG30RzGt3TyM6mvWQpSZo/1UQWcNodjLaiIP5c3N7cYXderUqIA==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-quantity/-/core-quantity-4.7.0-dev.15.tgz",
+      "integrity": "sha512-7PFhlhBWZ3oegvOezKyTeAGuOvO0VgFZbBW5zHeQ4Fe/J23eKRd8eEHYDfA1JAnLsR/lYC1KYLGjD+ZFO4kL7Q==",
       "dev": true,
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.6.0"
+        "@itwin/core-bentley": "^4.7.0-dev.15"
       }
     },
     "node_modules/@itwin/core-telemetry": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-telemetry/-/core-telemetry-4.6.0.tgz",
-      "integrity": "sha512-YG84Rz0b2+WcKUOh4yXViuBLJeK5VNkp7266iKP3pBF3IGWxPOP0rRzAqF2ZB1CFByUKMpuZ+LoYEbUEfYQILw==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/core-telemetry/-/core-telemetry-4.7.0-dev.15.tgz",
+      "integrity": "sha512-K3A8Fa7bTofcqTZrrT9bfjErVaKcvyseEGCLH1v8uYYAemj0lHxWWYMVT1npYIPH6gRadBnPMoVV5X914VoW5Q==",
       "dependencies": {
-        "@itwin/core-bentley": "4.6.0",
-        "@itwin/core-common": "4.6.0"
+        "@itwin/core-bentley": "4.7.0-dev.15",
+        "@itwin/core-common": "4.7.0-dev.15"
       }
     },
     "node_modules/@itwin/ecschema-metadata": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@itwin/ecschema-metadata/-/ecschema-metadata-4.6.0.tgz",
-      "integrity": "sha512-Si3nUnanvGYnPH4paqFbqz589wKKJP1Hs6gneGDdnADWqvc2730QAKUfRWPJK+ul0IoTVfXXCbrzmfo2u7/OWQ==",
+      "version": "4.7.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@itwin/ecschema-metadata/-/ecschema-metadata-4.7.0-dev.15.tgz",
+      "integrity": "sha512-Unec0AVY745mWw6MwRaajiT3JO9yxxjs+i1L9+egSed9JgU6gSm86Fn7U7ZyciMPO/cmgaUWJxvOmtJkcW62hw==",
       "dev": true,
       "dependencies": {
         "almost-equal": "^1.1.0"
       },
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.6.0",
-        "@itwin/core-quantity": "^4.6.0"
+        "@itwin/core-bentley": "^4.7.0-dev.15",
+        "@itwin/core-quantity": "^4.7.0-dev.15"
       }
     },
     "node_modules/@itwin/eslint-plugin": {
@@ -1486,14 +1606,14 @@
       }
     },
     "node_modules/@itwin/imodels-access-backend": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@itwin/imodels-access-backend/-/imodels-access-backend-5.0.4.tgz",
-      "integrity": "sha512-Hcg2BXn9Zwv/AqOIdUbpOP+II4Hpu7T+pPgRU0dDHskFLJu5ZvmalP8Uiw6T4wuCZ/tp87cvYIOZztkQgvSRRQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@itwin/imodels-access-backend/-/imodels-access-backend-5.1.1.tgz",
+      "integrity": "sha512-yh5/W/fMc/uPmbUEawXViK/rlMssaY6aKwlGCOCeNRtVWtfb+o2JmCm48gVFazrVrzO8/pQxhYVUKmTdq83Jew==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.1.0",
-        "@itwin/imodels-access-common": "5.0.4",
-        "@itwin/imodels-client-authoring": "5.3.1",
+        "@itwin/imodels-access-common": "5.1.1",
+        "@itwin/imodels-client-authoring": "5.5.0",
         "axios": "~1.6.4"
       },
       "peerDependencies": {
@@ -1503,12 +1623,12 @@
       }
     },
     "node_modules/@itwin/imodels-access-common": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@itwin/imodels-access-common/-/imodels-access-common-5.0.4.tgz",
-      "integrity": "sha512-8vlPtTs95xRExxpnFQFhXkvze3pdWHQpMCO7NhjcRXdLT2TdDGMKyijuZubwpDVVuz0XVLdbPxra6qZ2nJ8Lqg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@itwin/imodels-access-common/-/imodels-access-common-5.1.1.tgz",
+      "integrity": "sha512-ZXsHxQAIAZ98tflovq88QLmMhjL04UP1DH//gylqV1DyFUbWSoJOFtUdTG8OF3g+eSGoY92k1Gs4ASTZgtZLzQ==",
       "dev": true,
       "dependencies": {
-        "@itwin/imodels-client-management": "5.3.1"
+        "@itwin/imodels-client-management": "5.5.0"
       },
       "peerDependencies": {
         "@itwin/core-bentley": "^4.0.0",
@@ -1516,21 +1636,21 @@
       }
     },
     "node_modules/@itwin/imodels-client-authoring": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@itwin/imodels-client-authoring/-/imodels-client-authoring-5.3.1.tgz",
-      "integrity": "sha512-AQYLx5mddfmNBggkLObQVWBRoWcQAyRlhWpp2F+7tCtSpGiM8xqtzIni9wNWHU50d5SdOS+vp7riIzkxKFQC1g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@itwin/imodels-client-authoring/-/imodels-client-authoring-5.5.0.tgz",
+      "integrity": "sha512-s7qpCYjQbLlNFY0DOPfmLAoYDAqhD9Ezxp6zFZW5X2wWZYvC42BH9ez7CTn18rnfFWHA0hZSSh2ykNjcu+L8Ug==",
       "dev": true,
       "dependencies": {
         "@azure/storage-blob": "^12.7.0",
-        "@itwin/imodels-client-management": "5.3.1",
+        "@itwin/imodels-client-management": "5.5.0",
         "@itwin/object-storage-azure": "^2.0.0",
         "@itwin/object-storage-core": "^2.0.0"
       }
     },
     "node_modules/@itwin/imodels-client-management": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@itwin/imodels-client-management/-/imodels-client-management-5.3.1.tgz",
-      "integrity": "sha512-d/C8cmZYFvrJQqBecnro4VqlU5OESFGxPhWfuZP2+1LMwOki+o/JnHlpZojXFwW4a6Zt+30eyCEJ6AiskajvpA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@itwin/imodels-client-management/-/imodels-client-management-5.5.0.tgz",
+      "integrity": "sha512-IpTXy8VPgdjkyNcD2KAI+4njoHVgzpBeEIe5MF9dr0HjDySFVDb+nSajWi/Vn5t4Y0lzY5HB2+pyO3xX/5enfg==",
       "dev": true,
       "dependencies": {
         "axios": "~1.6.4"
@@ -1550,6 +1670,20 @@
       },
       "peerDependencies": {
         "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@itwin/node-cli-authorization/node_modules/@itwin/core-common": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.6.1.tgz",
+      "integrity": "sha512-SnnikTh7Rf1v4W8+uNBxMYQhssjMtLhWlimr7ura7IQGJkD/SyqaBGVBPnUAI/e6+PI83MdKs9LmaCRBhKH2GQ==",
+      "dev": true,
+      "dependencies": {
+        "flatbuffers": "~1.12.0",
+        "js-base64": "^3.6.1"
+      },
+      "peerDependencies": {
+        "@itwin/core-bentley": "^4.6.1",
+        "@itwin/core-geometry": "^4.6.1"
       }
     },
     "node_modules/@itwin/object-storage-azure": {
@@ -1623,6 +1757,20 @@
         "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
       }
     },
+    "node_modules/@itwin/oidc-signin-tool/node_modules/@itwin/core-common": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.6.1.tgz",
+      "integrity": "sha512-SnnikTh7Rf1v4W8+uNBxMYQhssjMtLhWlimr7ura7IQGJkD/SyqaBGVBPnUAI/e6+PI83MdKs9LmaCRBhKH2GQ==",
+      "dev": true,
+      "dependencies": {
+        "flatbuffers": "~1.12.0",
+        "js-base64": "^3.6.1"
+      },
+      "peerDependencies": {
+        "@itwin/core-bentley": "^4.6.1",
+        "@itwin/core-geometry": "^4.6.1"
+      }
+    },
     "node_modules/@itwin/service-authorization": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@itwin/service-authorization/-/service-authorization-1.2.1.tgz",
@@ -1636,6 +1784,20 @@
       },
       "peerDependencies": {
         "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@itwin/service-authorization/node_modules/@itwin/core-common": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.6.1.tgz",
+      "integrity": "sha512-SnnikTh7Rf1v4W8+uNBxMYQhssjMtLhWlimr7ura7IQGJkD/SyqaBGVBPnUAI/e6+PI83MdKs9LmaCRBhKH2GQ==",
+      "dev": true,
+      "dependencies": {
+        "flatbuffers": "~1.12.0",
+        "js-base64": "^3.6.1"
+      },
+      "peerDependencies": {
+        "@itwin/core-bentley": "^4.6.1",
+        "@itwin/core-geometry": "^4.6.1"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1718,19 +1880,6 @@
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
         "@rushstack/node-core-library": "4.0.2"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -2052,9 +2201,9 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
-      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
     "node_modules/@types/chai-as-promised": {
@@ -2164,15 +2313,15 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
-      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+      "version": "18.16.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.20.tgz",
+      "integrity": "sha512-nL54VfDjThdP2UXJXZao5wp76CDiDw4zSRO8d4Tk7UgDqNKGKVEQB0/t3ti63NS+YNNkIQDvwEAF04BO+WYu7Q=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
@@ -2574,6 +2723,18 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2608,17 +2769,6 @@
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
       "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==",
       "dev": true
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/ansi-escapes": {
       "version": "5.0.0",
@@ -2659,8 +2809,7 @@
     "node_modules/ansi-sequence-parser": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2994,8 +3143,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3076,12 +3224,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4066,21 +4214,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/es-abstract": {
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
@@ -5038,6 +5171,28 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -5060,9 +5215,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5757,6 +5912,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -5768,6 +5936,19 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -7073,8 +7254,7 @@
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -7122,7 +7302,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9170,7 +9349,6 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
       "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
-      "dev": true,
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -9181,8 +9359,7 @@
     "node_modules/shiki/node_modules/jsonc-parser": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
@@ -9542,6 +9719,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/subarg": {
       "version": "1.0.0",
@@ -9910,42 +10093,38 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
-      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
-      "dev": true,
-      "peer": true,
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
-        "shiki": "^0.14.1"
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
       }
     },
     "node_modules/typedoc-plugin-merge-modules": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-4.1.0.tgz",
-      "integrity": "sha512-0Qax5eSaiP86zX9LlQQWANjtgkMfSHt6/LRDsWXfK45Ifc3lrgjZG4ieE87BMi3p12r/F0qW9sHQRB18tIs0fg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-5.1.0.tgz",
+      "integrity": "sha512-jXH27L/wlxFjErgBXleh3opVgjVTXFEuBo68Yfl18S9Oh/IqxK6NV94jlEJ9hl4TXc9Zm2l7Rfk41CEkcCyvFQ==",
       "dev": true,
       "peerDependencies": {
-        "typedoc": "0.23.x || 0.24.x"
+        "typedoc": "0.24.x || 0.25.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9954,8 +10133,6 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9967,16 +10144,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uid-safe": {
@@ -10236,14 +10413,12 @@
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "node_modules/vscode-textmate": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/connector-framework",
-  "version": "2.1.2",
+  "version": "2.2.0-dev.1",
   "description": "iTwin Connector Framework",
   "main": "lib/src/connector-framework.js",
   "typings": "lib/src/connector-framework.d.ts",
@@ -44,29 +44,29 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@itwin/build-tools": "^4.6.0",
-    "@itwin/core-bentley": "^4.6.0",
-    "@itwin/core-common": "^4.6.0",
-    "@itwin/core-geometry": "^4.6.0",
-    "@itwin/core-quantity": "^4.6.0",
-    "@itwin/ecschema-metadata": "^4.6.0",
+    "@itwin/build-tools": "^4.7.0-dev.15",
+    "@itwin/core-bentley": "^4.7.0-dev.15",
+    "@itwin/core-common": "^4.7.0-dev.15",
+    "@itwin/core-geometry": "^4.7.0-dev.15",
+    "@itwin/core-quantity": "^4.7.0-dev.15",
+    "@itwin/ecschema-metadata": "^4.7.0-dev.15",
     "@itwin/eslint-plugin": "^4.0.2",
-    "@itwin/imodels-access-backend": "^5.0.4",
-    "@itwin/imodels-client-authoring": "^5.3.1",
+    "@itwin/imodels-access-backend": "^5.1.1",
+    "@itwin/imodels-client-authoring": "^5.5.0",
     "@itwin/node-cli-authorization": "^2.0.2",
     "@itwin/oidc-signin-tool": "^4.3.5",
-    "@types/chai": "^4.1.4",
+    "@types/chai": "4.3.1",
     "@types/chai-as-promised": "^7",
-    "@types/mocha": "^8.2.2",
-    "@types/node": "^14.0.0",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "~18.16.20",
     "@types/object-hash": "^1.3.0",
     "@types/request-promise-native": "^1.0.17",
     "@types/ws": "^8.5.3",
-    "chai": "^4.1.2",
+    "chai": "^4.3.10",
     "chai-as-promised": "^7",
     "cpx2": "^3.0.0",
     "dotenv": "10.0.0",
-    "eslint": "^8.44.0",
+    "eslint": "^8.56.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.1",
     "mocha": "^10.2.0",
@@ -77,11 +77,11 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.21",
     "ts-node": "10.8.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^4.6.0",
-    "@itwin/core-common": "^4.6.0",
+    "@itwin/core-bentley": "^4.7.0-dev.15",
+    "@itwin/core-common": "^4.7.0-dev.15",
     "@itwin/node-cli-authorization": "^2.0.1"
   },
   "husky": {
@@ -96,7 +96,8 @@
     ]
   },
   "dependencies": {
-    "@itwin/core-backend": "^4.6.0",
-    "cross-env": "^7.0.3"
+    "@itwin/core-backend": "^4.7.0-dev.15",
+    "cross-env": "^7.0.3",
+    "typedoc": "^0.25.13"
   }
 }


### PR DESCRIPTION
opening this as draft b/c need to figure out alternative to --legacy-peer-deps for npm install command.