### PR TITLE
Add tests for ConnectorAuthenticationManager to get coverage into the green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ manifest.itsyn.yml
 # documentation
 documentation/file.json
 documentation/index.ts
+
+.configStore/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itwin/connector-framework",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itwin/connector-framework",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@itwin/core-backend": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:trimming": "npm run build && nyc mocha --grep trimming",
     "test:unmap": "npm run build && nyc mocha --grep unmap",
     "test:larger-source-set":"npm run build && nyc mocha --grep larger-source-set",
+    "test:AuthClient":"npm run build && nyc mocha --grep AuthClient",
     "test:connector": "node lib/test/TestConnector/Main.js test/assets/TestArgs.json",
     "documentation": "cross-env RUSHSTACK_FILE_ERROR_BASE_FOLDER=$npm_config_local_prefix betools docs --source=./src --out=./documentation --json=./documentation/file.json --tsIndexFile=./connector-framework.ts --onlyJson"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:trimming": "npm run build && nyc mocha --grep trimming",
     "test:unmap": "npm run build && nyc mocha --grep unmap",
     "test:larger-source-set":"npm run build && nyc mocha --grep larger-source-set",
-    "test:AuthClient":"npm run build && nyc mocha --grep AuthClient",
+    "test:authclient":"npm run build && nyc mocha --grep AuthClient",
     "test:connector": "node lib/test/TestConnector/Main.js test/assets/TestArgs.json",
     "documentation": "cross-env RUSHSTACK_FILE_ERROR_BASE_FOLDER=$npm_config_local_prefix betools docs --source=./src --out=./documentation --json=./documentation/file.json --tsIndexFile=./connector-framework.ts --onlyJson"
   },

--- a/src/ConnectorAuthenticationManager.ts
+++ b/src/ConnectorAuthenticationManager.ts
@@ -51,6 +51,11 @@ abstract class CachedTokenClient implements AuthorizationClient {
  */
 export class CallbackUrlClient extends CachedTokenClient {
   private _callbackUrl: AccessTokenCallbackUrl;
+  protected _fetch = async (): Promise<Response> => {
+    const response =await fetch(this._callbackUrl);
+    return response;
+  };
+
   constructor(callbackUrl: AccessTokenCallbackUrl) {
     super();
     this._callbackUrl = callbackUrl;
@@ -58,7 +63,41 @@ export class CallbackUrlClient extends CachedTokenClient {
   public override async getAccessToken(): Promise<string> {
     return this.getCachedTokenIfNotExpired (async () => {
 
-      const response = await fetch(this._callbackUrl);
+      const response = await this._fetch();
+      const responseJSON = await response.json();
+      const tokenStr = responseJSON.access_token;
+      const expiresIn = await responseJSON.expires_in;
+      const expiration = Date.now() + expiresIn*1E3; // convert to milliseconds
+      const tePair: TokenExpirationPair = {token:tokenStr, expiration};
+      return tePair;
+    });
+  }
+}
+
+export interface DummyCallbackUrlParams {
+  callbackUrl: AccessTokenCallbackUrl;  // dummy callback URL - for show only
+  token: string;                        // the token to return
+  expiration: number;                   // in seconds
+}
+
+export class DummyCallbackUrlClient extends CallbackUrlClient {
+  private _dummyToken: string;
+  private _dummyExpiration: number;
+
+  constructor(dummyParams: DummyCallbackUrlParams) {
+    super(dummyParams.callbackUrl);
+    this._dummyToken = dummyParams.token;
+    this._dummyExpiration = dummyParams.expiration;
+    this._fetch = async (): Promise<Response> => {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      return new Response(JSON.stringify({access_token: this._dummyToken, expires_in: this._dummyExpiration}));
+    };
+  }
+
+  public override async getAccessToken(): Promise<string> {
+    return this.getCachedTokenIfNotExpired (async () => {
+
+      const response = await this._fetch();
       const responseJSON = await response.json();
       const tokenStr = responseJSON.access_token;
       const expiresIn = await responseJSON.expires_in;
@@ -95,6 +134,7 @@ interface ConnectorAuthenticationManagerParams {
   callback?: AccessTokenGetter;
   callbackUrl?: AccessTokenCallbackUrl;
   authClientConfig?: NodeCliAuthorizationConfiguration;
+  dummyParams?: DummyCallbackUrlParams;
 }
 
 /**
@@ -131,19 +171,23 @@ export class ConnectorAuthenticationManager {
 
   }
 
-  public initializeCallbackClient(callback: AccessTokenGetter): CallbackClient {
+  private initializeCallbackClient(callback: AccessTokenGetter): CallbackClient {
     return new CallbackClient (callback);
   }
 
-  public initializeCallbackUrlClient(authClient: AccessTokenCallbackUrl){
+  private initializeCallbackUrlClient(authClient: AccessTokenCallbackUrl){
     return new CallbackUrlClient(authClient);
   }
 
-  public async initializeInteractiveClient(authClient: NodeCliAuthorizationConfiguration){
+  private async initializeInteractiveClient(authClient: NodeCliAuthorizationConfiguration){
     const ncliClient = new NodeCliAuthorizationClient(authClient);
     // From docs... If signIn hasn't been called, the AccessToken will remain empty.
     await ncliClient.signIn();
     return ncliClient;
+  }
+
+  private async initializeDummyCallbackUrlClient(dummyParams: DummyCallbackUrlParams){
+    return new DummyCallbackUrlClient(dummyParams);
   }
 
   public async initialize() {
@@ -153,6 +197,8 @@ export class ConnectorAuthenticationManager {
       this._authClient = this.initializeCallbackUrlClient(this._cAMParams.callbackUrl);
     else if (this._cAMParams.authClientConfig)
       this._authClient = await this.initializeInteractiveClient(this._cAMParams.authClientConfig);
+    else if (this._cAMParams.dummyParams)
+      this._authClient = await this.initializeDummyCallbackUrlClient(this._cAMParams.dummyParams);
     else
       throw new Error(`Must pass callback, callbackUrl or an auth client!`);
   }

--- a/test/ConnectorTestUtils.ts
+++ b/test/ConnectorTestUtils.ts
@@ -45,7 +45,7 @@ export function setupLoggingWithAPIMRateTrap() {
 /* eslint-disable no-console */
 
 /** Loads the provided `.env` file into process.env */
-function loadEnv(envFile: string) {
+export function loadEnv(envFile: string) {
   if (!fs.existsSync(envFile))
     return;
 

--- a/test/TestConnector/TestConnector.ts
+++ b/test/TestConnector/TestConnector.ts
@@ -176,8 +176,8 @@ export default class TestConnector extends BaseConnector {
     deleteElementTree(this.synchronizer.imodel, this.jobSubject.id);
     this.synchronizer.imodel.elements.deleteElement(this.repositoryLinkId);      
     // bf: ADO# 1387737 - Also delete the ExternalSource
-    if (this._externalSourceId != undefined)
-       this.synchronizer.imodel.elements.deleteElement(this._externalSourceId);
+    if (this._externalSourceId !== undefined)
+      this.synchronizer.imodel.elements.deleteElement(this._externalSourceId);
   }
 
   public getApplicationVersion(): string {
@@ -223,8 +223,6 @@ export default class TestConnector extends BaseConnector {
     const partitionId = this.synchronizer.imodel.elements.insertElement(partitionProps);
 
     return this.synchronizer.imodel.models.insertModel({ classFullName: TestConnectorGroupModel.classFullName, modeledElement: { id: partitionId } });
-
-
   }
 
   private queryGroupModel(): Id64String | undefined {

--- a/test/integration/ConnectorRunner.test.ts
+++ b/test/integration/ConnectorRunner.test.ts
@@ -2,15 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import type { AccessToken, Id64String} from "@itwin/core-bentley";
-import { BentleyStatus } from "@itwin/core-bentley";
+import { AccessToken, BentleyStatus, Id64String} from "@itwin/core-bentley";
 import { BriefcaseDb, BriefcaseManager, IModelHost, IModelJsFs } from "@itwin/core-backend";
-import type { TestBrowserAuthorizationClientConfiguration} from "@itwin/oidc-signin-tool";
-import { TestUtility} from "@itwin/oidc-signin-tool";
+import { TestBrowserAuthorizationClientConfiguration, TestUtility} from "@itwin/oidc-signin-tool";
 import { expect } from "chai";
 import { ConnectorRunner } from "../../src/ConnectorRunner";
-import type { HubArgsProps} from "../../src/Args";
-import { HubArgs, JobArgs } from "../../src/Args";
+import { HubArgs, HubArgsProps, JobArgs } from "../../src/Args";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
@@ -21,13 +18,13 @@ import { TestIModelManager } from "./TestIModelManager";
 describe("iTwin Connector Fwk (#integration)", () => {
 
   let testProjectId: Id64String;
-  let newImodelName = process.env.test_new_imodel_name ? process.env.test_new_imodel_name : "ConnectorFramework";
-  let updateImodelName = process.env.test_existing_imodel_name? process.env.test_existing_imodel_name: newImodelName + "Update";
-  let unmapImodelName = process.env.test_unmap_imodel_name? process.env.test_unmap_imodel_name: newImodelName + "Unmap";
-  
+  const newImodelName = process.env.test_new_imodel_name ? process.env.test_new_imodel_name : "ConnectorFramework";
+  const updateImodelName = process.env.test_existing_imodel_name? process.env.test_existing_imodel_name: `${newImodelName  }Update`;
+  const unmapImodelName = process.env.test_unmap_imodel_name? process.env.test_unmap_imodel_name: `${newImodelName  }Unmap`;
+
   let testClientConfig: TestBrowserAuthorizationClientConfiguration;
   let token: AccessToken| undefined;
-  let callbackUrl : string|undefined;
+  let callbackUrl: string|undefined;
 
   const testConnector = path.join("..", "lib", "test", "TestConnector", "TestConnector.js");
 
@@ -44,10 +41,10 @@ describe("iTwin Connector Fwk (#integration)", () => {
       clientId: process.env.test_client_id!,
       redirectUri: process.env.test_redirect_uri!,
       scope: process.env.test_scopes!,
-      authority: `https://${process.env.imjs_url_prefix}ims.bentley.com`
+      authority: `https://${process.env.imjs_url_prefix}ims.bentley.com`,
     };
 
-    callbackUrl = process.env.test_callbackUrl!
+    callbackUrl = process.env.test_callbackUrl!;
 
     const userCred = {
       email: process.env.test_user_name!,
@@ -128,7 +125,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
     } as HubArgsProps);
 
   if (callbackUrl) {
-    hubArgs.tokenCallbackUrl = callbackUrl;  
+    hubArgs.tokenCallbackUrl = callbackUrl;
     }
   else {
     hubArgs.clientConfig = testClientConfig;
@@ -162,7 +159,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
     } as HubArgsProps);
 
   if (callbackUrl) {
-    hubArgs.tokenCallbackUrl = callbackUrl;  
+    hubArgs.tokenCallbackUrl = callbackUrl;
     }
   else {
     hubArgs.clientConfig = testClientConfig;
@@ -200,7 +197,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
     } as HubArgsProps);
 
     if (callbackUrl) {
-      hubArgs.tokenCallbackUrl = callbackUrl;  
+      hubArgs.tokenCallbackUrl = callbackUrl;
       }
     else {
       hubArgs.clientConfig = testClientConfig;

--- a/test/standalone/AccessToken.test.ts
+++ b/test/standalone/AccessToken.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+import { ConnectorAuthenticationManager } from "../../src/ConnectorAuthenticationManager";
+import {loadEnv} from "../../test/ConnectorTestUtils";
+import * as path from "path";
+import { NodeCliAuthorizationConfiguration } from "@itwin/node-cli-authorization";
+describe("ConnectorAuthenticationManager (#standalone) - AuthClient", async () => {
+  let authManager: ConnectorAuthenticationManager;
+  loadEnv(path.join(__dirname, "../../", ".env"));
+
+  const testClientConfig: NodeCliAuthorizationConfiguration = {
+    clientId: process.env.desktop_client_id!,
+    redirectUri: process.env.desktop_redirect_uri!,
+    scope: process.env.desktop_scopes!,
+    issuerUrl: `https://${process.env.imjs_url_prefix || ""}ims.bentley.com`,
+  };
+
+  beforeEach(async () => {
+
+  });
+
+  it("should return true when isAuthenticated is called with valid credentials", async () => {
+
+    authManager = new ConnectorAuthenticationManager({authClientConfig: testClientConfig});
+    await authManager.initialize();
+    const token = await authManager.getAccessToken();
+    expect(token !== undefined).to.be.true;
+  });
+});

--- a/test/standalone/AccessToken.test.ts
+++ b/test/standalone/AccessToken.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { ConnectorAuthenticationManager } from "../../src/ConnectorAuthenticationManager";
+import { ConnectorAuthenticationManager, DummyCallbackUrlParams } from "../../src/ConnectorAuthenticationManager";
 import {loadEnv} from "../../test/ConnectorTestUtils";
 import * as path from "path";
 import { NodeCliAuthorizationConfiguration } from "@itwin/node-cli-authorization";
@@ -57,6 +57,24 @@ describe("AuthClient (#standalone) - using callback", async () => {
       return token!;
     };
     authManager = new ConnectorAuthenticationManager({callback: tokenCallback});
+    await authManager.initialize();
+    assert.isDefined(await authManager.getAccessToken());
+  });
+});
+
+describe("AuthClient (#standalone) - using (dummy) callback URL", async () => {
+  let authManager: ConnectorAuthenticationManager;
+
+  // beforeEach(async () => {});
+
+  it("getAccessToken should return a token", async () => {
+    const dummyParams:  DummyCallbackUrlParams = {
+      callbackUrl: "http://localhost:3000",
+      token: "dummy",
+      expiration: 3600,
+    };
+
+    authManager = new ConnectorAuthenticationManager({dummyParams});
     await authManager.initialize();
     assert.isDefined(await authManager.getAccessToken());
   });

--- a/test/standalone/AccessToken.test.ts
+++ b/test/standalone/AccessToken.test.ts
@@ -1,9 +1,11 @@
-import { expect } from "chai";
+import { assert } from "chai";
 import { ConnectorAuthenticationManager } from "../../src/ConnectorAuthenticationManager";
 import {loadEnv} from "../../test/ConnectorTestUtils";
 import * as path from "path";
 import { NodeCliAuthorizationConfiguration } from "@itwin/node-cli-authorization";
-describe("ConnectorAuthenticationManager (#standalone) - AuthClient", async () => {
+import { TestBrowserAuthorizationClient } from "@itwin/oidc-signin-tool";
+import { AccessToken } from "@itwin/core-bentley";
+describe("AuthClient (#standalone) - using Node Cli Client", async () => {
   let authManager: ConnectorAuthenticationManager;
   loadEnv(path.join(__dirname, "../../", ".env"));
 
@@ -18,11 +20,44 @@ describe("ConnectorAuthenticationManager (#standalone) - AuthClient", async () =
 
   });
 
-  it("should return true when isAuthenticated is called with valid credentials", async () => {
-
+  it("getAccessToken should return a token", async () => {
     authManager = new ConnectorAuthenticationManager({authClientConfig: testClientConfig});
     await authManager.initialize();
-    const token = await authManager.getAccessToken();
-    expect(token !== undefined).to.be.true;
+    assert.isDefined(await authManager.getAccessToken());
+  });
+});
+
+describe("AuthClient (#standalone) - using callback", async () => {
+  let authManager: ConnectorAuthenticationManager;
+  let token;
+  loadEnv(path.join(__dirname, "../../", ".env"));
+
+  beforeEach(async () => {
+    const testClientConfig = {
+      clientId: process.env.test_client_id!,
+      redirectUri: process.env.test_redirect_uri!,
+      scope: process.env.test_scopes!,
+      authority: `https://${process.env.imjs_url_prefix}ims.bentley.com`,
+    };
+
+    const userCred = {
+      email: process.env.test_user_name!,
+      password: process.env.test_user_password!,
+    };
+    const client = new TestBrowserAuthorizationClient(testClientConfig, userCred);
+    token = await client.getAccessToken();
+
+    if (!token) {
+      throw new Error("Token not defined");
+    }
+  });
+
+  it("getAccessToken should return a token", async () => {
+    const tokenCallback = async (): Promise<AccessToken> => {
+      return token!;
+    };
+    authManager = new ConnectorAuthenticationManager({callback: tokenCallback});
+    await authManager.initialize();
+    assert.isDefined(await authManager.getAccessToken());
   });
 });

--- a/test/standalone/AccessToken.test.ts
+++ b/test/standalone/AccessToken.test.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import { NodeCliAuthorizationConfiguration } from "@itwin/node-cli-authorization";
 import { TestBrowserAuthorizationClient } from "@itwin/oidc-signin-tool";
 import { AccessToken } from "@itwin/core-bentley";
-describe("AuthClient (#standalone) - using Node Cli Client", async () => {
+describe("AuthClient - using Node Cli Client", async () => {
   let authManager: ConnectorAuthenticationManager;
   loadEnv(path.join(__dirname, "../../", ".env"));
 
@@ -27,7 +27,7 @@ describe("AuthClient (#standalone) - using Node Cli Client", async () => {
   });
 });
 
-describe("AuthClient (#standalone) - using callback", async () => {
+describe("AuthClient - using callback", async () => {
   let authManager: ConnectorAuthenticationManager;
   let token;
   loadEnv(path.join(__dirname, "../../", ".env"));
@@ -94,7 +94,7 @@ describe("AuthClient (#standalone) - using (dummy) callback URL", async () => {
     await new Promise((resolve) => setTimeout(resolve, (shortExpiration + 1)*1E3));
 
     // Token should be expired
-    // This is admittedly not the greatest test.  It's already tested on first request
+    // This is admittedly not the greatest test b/c we can't be certain we're not getting a cached token.
     // Since the cached token is tested with the integration tests and b/c we are already at 84% coverage, ...
     // we won't take this farther at this time. We could make the CachedTokenClient and CachedToken public
     // through accessor methods and test the expiration directly.


### PR DESCRIPTION
**ADO# 1456590** - Fix coverage for ConnectorAuthenticationManager

Before ~31%
![thirtypercent](https://github.com/iTwin/connector-framework/assets/66284944/bd3a99f5-4b63-4527-b893-7c165e1dcbc1)

Final ~ 77% 
To avoid requiring correct environment setup for standalone tests, we removed '#standalone' from three of the four new tests.  We only lose about 7% coverage see below. 
![StandaloneWSplit](https://github.com/iTwin/connector-framework/assets/66284944/d98fd358-154f-4194-bbdd-5c3a57ed56bf)

After ~84%
![eightfourpercent](https://github.com/iTwin/connector-framework/assets/66284944/6ea47314-034c-49d0-b0c0-c900526101c6)
