### PR TITLE
refactor updateResultsInIModelForChildren in Synchronizer.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.3.0-dev.1
 
 - add support for ChangeSetGroups
+- refactor updateResultsInIModelForChildren in Synchronizer.ts
 
 ## 2.2.2
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:larger-source-set":"npm run build && nyc mocha --grep larger-source-set",
     "test:authclient":"npm run build && nyc mocha --grep AuthClient",
     "test:change-set-group":"npm run build && nyc mocha --grep change-set-group",
+    "test:interspersed":"npm run build && nyc mocha --grep interspersed",
     "test:connector": "node lib/test/TestConnector/Main.js test/assets/TestArgs.json",
     "documentation": "cross-env RUSHSTACK_FILE_ERROR_BASE_FOLDER=$npm_config_local_prefix betools docs --source=./src --out=./documentation --json=./documentation/file.json --tsIndexFile=./connector-framework.ts --onlyJson"
   },

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -832,10 +832,9 @@ export class Synchronizer {
     for (let updated = 0; updated < numUpdates; i++) {
       // If we have new elements, then we should insert them.
       // rather than update them.
-      if (results.childElements[i].itemState === ItemState.New) {
+      if (results.childElements[i].itemState === ItemState.New)
         this.insertResultsIntoIModel(results.childElements[i], parentAspectProps);
-        numNew--;
-      } else {
+      else {
       // reuse ids of existing children
         results.childElements[i].elementProps.id = existingChildren[updated];
         this.updateResultsInIModel(results.childElements[i], parentAspectProps);

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -807,6 +807,9 @@ export class Synchronizer {
             return stat;
           }
         } else if (childRes.itemState === ItemState.New) {
+          if (childRes.elementProps.id !== undefined) {
+            throw new IModelError(IModelStatus.InvalidId, "New child element should not have an id!");
+          }
           const stat = this.insertResultsIntoIModel(childRes, parentAspectProps);
           if (stat !== IModelStatus.Success)
             return stat;

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -820,9 +820,10 @@ export class Synchronizer {
     // So, if we get here, we have a problem.
     Logger.logWarning(LoggerCategories.Framework, "Child elements do not have ElementIds.  Attempting to update the children by mapping to existing children.");
     // We need to match existingChildren with only child elements that are changed or unchanged.
-    const count = Math.min(existingChildren.length, results.childElements.length - numNew);
+    const numUpdates = Math.min(existingChildren.length, results.childElements.length - numNew);
     let i = 0;
-    for (; i < count; ) {
+
+    for (let updated = 0; updated < numUpdates; i++) {
       // If we have new elements, then we should insert them.
       // rather than update them.
       if (results.childElements[i].itemState === ItemState.New) {
@@ -830,13 +831,13 @@ export class Synchronizer {
         numNew--;
       } else {
       // reuse ids of existing children
-        results.childElements[i].elementProps.id = existingChildren[i];
+        results.childElements[i].elementProps.id = existingChildren[updated];
         this.updateResultsInIModel(results.childElements[i], parentAspectProps);
-        i++;
+        updated++;
       }
     }
-    for (; i < results.childElements.length; i++) {
-      this.insertResultsIntoIModel(results.childElements[i], parentAspectProps);
+    for (let j = 0; j < numNew; j++) {
+      this.insertResultsIntoIModel(results.childElements[i+j], parentAspectProps);
     }
     return IModelStatus.Success;
   }

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -836,8 +836,8 @@ export class Synchronizer {
         updated++;
       }
     }
-    for (let j = 0; j < numNew; j++) {
-      this.insertResultsIntoIModel(results.childElements[i+j], parentAspectProps);
+    for (;i < results.childElements.length; i++) {
+      this.insertResultsIntoIModel(results.childElements[i], parentAspectProps);
     }
     return IModelStatus.Success;
   }

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -774,7 +774,7 @@ export class Synchronizer {
     }
     results.childElements.forEach((child) => {
 
-      if (!getResultIdStatus (child))
+      if (idsOk && !getResultIdStatus (child))
         idsOk = false; // if any one child is missing an id, then the group of children is considered missing
 
       if (child.itemState === ItemState.New)
@@ -818,9 +818,15 @@ export class Synchronizer {
     // The specified children do not have ElementIds.
     // JC: This is the no id case and the first thing it checks in updateResultsInIModel is if the id is undefined.
     // So, if we get here, we have a problem.
-    Logger.logWarning(LoggerCategories.Framework, "Child elements do not have ElementIds.  Attempting to update the children by mapping to existing children.");
+    Logger.logWarning(LoggerCategories.Framework, "At least one child element requiring update is missing an ElementId.  Attempting to update the children by arbitrarily mapping to existing children.");
     // We need to match existingChildren with only child elements that are changed or unchanged.
-    const numUpdates = Math.min(existingChildren.length, results.childElements.length - numNew);
+    const numReqUpdates = results.childElements.length - numNew;
+    let numUpdates = numReqUpdates;
+    if (numReqUpdates > existingChildren.length) {
+      Logger.logError(LoggerCategories.Framework, `More child elements than existing children.  ${numReqUpdates - existingChildren.length} child elements will be added as new.`);
+      numUpdates = existingChildren.length;
+    }
+
     let i = 0;
 
     for (let updated = 0; updated < numUpdates; i++) {

--- a/test/standalone/Synchronizer.test.ts
+++ b/test/standalone/Synchronizer.test.ts
@@ -295,9 +295,6 @@ describe("synchronizer #standalone", () => {
       count(query("raspberries"), 1);
     });
 
-    // TODO: This one fails, skipping so that it passes CI. Need to fix, it's a bug in the
-    // synchronizer!
-    // vvvv
     it("update modified root element with children, larger-source-set", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
@@ -327,5 +324,68 @@ describe("synchronizer #standalone", () => {
       count(query("raspberries"), 1);
       count(query("blueberries"), 1);
     });
+
+    it("update modified root element with children, larger-source-set but w/ new child element first in list", () => {
+      const synchronizer = new Synchronizer(imodel, false);
+      const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const blueberryProps = DefinitionGroup.create (imodel, model.id!, Code.createEmpty(), false);
+      blueberryProps.userLabel = "definitions of blueberries";
+
+      berryTree.childElements!.unshift({
+        itemState: ItemState.New,
+        elementProps: blueberryProps.toJSON(),
+      });
+
+      berryTree.childElements![0].itemState = ItemState.New;
+      berryTree.childElements![0].elementProps.id = undefined;
+      berryTree.childElements![1].itemState = ItemState.Unchanged;
+      berryTree.childElements![2].itemState = ItemState.Unchanged;
+
+      // Patch berry definition group.
+      berryTreeMeta.version = "1.0.1";
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
+
+      count(query("strawberries"), 1);
+      count(query("raspberries"), 1);
+      count(query("blueberries"), 1);
+    });
+  });
+
+  it("update modified root element with children, larger-source-set but w/ one new child elements and no id", () => {
+    const synchronizer = new Synchronizer(imodel, false);
+    const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
+
+    assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+    const blueberryProps = DefinitionGroup.create (imodel, model.id!, Code.createEmpty(), false);
+    blueberryProps.userLabel = "definitions of blueberries";
+
+    berryTree.childElements!.pop ();
+    berryTree.childElements!.pop ();
+
+    berryTree.childElements!.push({
+      itemState: ItemState.New,
+      elementProps: blueberryProps.toJSON(),
+    });
+
+    berryTree.childElements![0].itemState = ItemState.New;
+    berryTree.childElements![0].elementProps.id = undefined;
+
+    // Patch berry definition group.
+    berryTreeMeta.version = "1.0.1";
+
+    assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+    const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
+
+    count(query("strawberries"), 1);
+    count(query("raspberries"), 1);
+    count(query("blueberries"), 1);
   });
 });

--- a/test/standalone/Synchronizer.test.ts
+++ b/test/standalone/Synchronizer.test.ts
@@ -325,7 +325,7 @@ describe("synchronizer #standalone", () => {
       count(query("blueberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ new child element first in list", () => {
+    it("update modified ..., larger ... but w/ new child element first in list", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -356,7 +356,7 @@ describe("synchronizer #standalone", () => {
       count(query("blueberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ one new child elements and no id", () => {
+    it("update modified ..., larger ... but w/ one new child elements and no id", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -386,7 +386,7 @@ describe("synchronizer #standalone", () => {
       count(query("blueberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set and w/ existing child elements but all missing ids", () => {
+    it("update modified ..., larger ... and w/ existing child elements but all missing ids", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -412,7 +412,7 @@ describe("synchronizer #standalone", () => {
       count(query("raspberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ existing child elements and several new elements interspersed all missing ids", () => {
+    it("update modified ..., larger ... but w/ existing child elements and several new elements interspersed all missing ids", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -467,7 +467,7 @@ describe("synchronizer #standalone", () => {
       count(query("raspberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ existing child elements and several new elements interspersed w Ids", () => {
+    it("update modified ..., larger ... but w/ existing child elements and several new elements interspersed w Ids", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -520,7 +520,7 @@ describe("synchronizer #standalone", () => {
       count(query("raspberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ more unchanged child elements than existing (some need to be inserted as new)", () => {
+    it("update modified ..., larger ... but w/ more unchanged child elements than existing (some need to be inserted as new)", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 

--- a/test/standalone/Synchronizer.test.ts
+++ b/test/standalone/Synchronizer.test.ts
@@ -386,7 +386,7 @@ describe("synchronizer #standalone", () => {
       count(query("blueberries"), 1);
     });
 
-    it("update modified root element with children, larger-source-set but w/ existing child elements but all missing ids", () => {
+    it("update modified root element with children, larger-source-set and w/ existing child elements but all missing ids", () => {
       const synchronizer = new Synchronizer(imodel, false);
       const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
 
@@ -408,6 +408,61 @@ describe("synchronizer #standalone", () => {
 
       const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
 
+      count(query("strawberries"), 1);
+      count(query("raspberries"), 1);
+    });
+
+    it("update modified root element with children, larger-source-set but w/ existing child elements and several new elements interspersed all missing ids", () => {
+      const synchronizer = new Synchronizer(imodel, false);
+      const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const blueberryPropsArr: DefinitionGroup[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const blueberryProps = DefinitionGroup.create (imodel, model.id!, Code.createEmpty(), false);
+        blueberryProps.userLabel = `definitions of blueberries`;
+        blueberryPropsArr.push(blueberryProps);
+      }
+
+      const poppedChild = berryTree.childElements!.pop ();
+
+      berryTree.childElements!.unshift({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[0].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[1].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[2].toJSON(),
+      });
+
+      berryTree.childElements!.push(poppedChild!);
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[3].toJSON(),
+      });
+
+      berryTree.childElements![1].itemState = ItemState.Unchanged;
+      berryTree.childElements![1].elementProps.id = undefined;
+      berryTree.childElements![4].itemState = ItemState.Unchanged;
+      berryTree.childElements![4].elementProps.id = undefined;
+
+      // Patch berry definition group.
+      berryTreeMeta.version = "1.0.1";
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
+
+      count(query("blueberries"), 4);
       count(query("strawberries"), 1);
       count(query("raspberries"), 1);
     });

--- a/test/standalone/Synchronizer.test.ts
+++ b/test/standalone/Synchronizer.test.ts
@@ -466,5 +466,117 @@ describe("synchronizer #standalone", () => {
       count(query("strawberries"), 1);
       count(query("raspberries"), 1);
     });
+
+    it("update modified root element with children, larger-source-set but w/ existing child elements and several new elements interspersed w Ids", () => {
+      const synchronizer = new Synchronizer(imodel, false);
+      const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const blueberryPropsArr: DefinitionGroup[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const blueberryProps = DefinitionGroup.create (imodel, model.id!, Code.createEmpty(), false);
+        blueberryProps.userLabel = `definitions of blueberries`;
+        blueberryPropsArr.push(blueberryProps);
+      }
+
+      const poppedChild = berryTree.childElements!.pop ();
+
+      berryTree.childElements!.unshift({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[0].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[1].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[2].toJSON(),
+      });
+
+      berryTree.childElements!.push(poppedChild!);
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[3].toJSON(),
+      });
+
+      berryTree.childElements![1].itemState = ItemState.Unchanged;
+      berryTree.childElements![4].itemState = ItemState.Unchanged;
+
+      // Patch berry definition group.
+      berryTreeMeta.version = "1.0.1";
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
+
+      count(query("blueberries"), 4);
+      count(query("strawberries"), 1);
+      count(query("raspberries"), 1);
+    });
+
+    it("update modified root element with children, larger-source-set but w/ more unchanged child elements than existing (some need to be inserted as new)", () => {
+      const synchronizer = new Synchronizer(imodel, false);
+      const { model, berryTree, berryTreeMeta } = berryGroups(synchronizer);
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const blueberryPropsArr: DefinitionGroup[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const blueberryProps = DefinitionGroup.create (imodel, model.id!, Code.createEmpty(), false);
+        blueberryProps.userLabel = `definitions of blueberries`;
+        blueberryPropsArr.push(blueberryProps);
+      }
+
+      const poppedChild = berryTree.childElements!.pop ();
+
+      berryTree.childElements!.unshift({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[0].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[1].toJSON(),
+      });
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[2].toJSON(),
+      });
+
+      berryTree.childElements!.push(poppedChild!);
+
+      berryTree.childElements!.push({
+        itemState: ItemState.New,
+        elementProps: blueberryPropsArr[3].toJSON(),
+      });
+
+      berryTree.childElements![1].itemState = ItemState.Unchanged;
+      berryTree.childElements![1].elementProps.id = undefined;
+      berryTree.childElements![2].itemState = ItemState.Unchanged;
+      berryTree.childElements![2].elementProps.id = undefined;
+      berryTree.childElements![3].itemState = ItemState.Unchanged;
+      berryTree.childElements![3].elementProps.id = undefined;
+      berryTree.childElements![4].itemState = ItemState.Unchanged;
+      berryTree.childElements![4].elementProps.id = undefined;
+
+      // Patch berry definition group.
+      berryTreeMeta.version = "1.0.1";
+
+      assert.strictEqual(synchronizer.updateIModel(berryTree, berryTreeMeta), IModelStatus.Success);
+
+      const query = (label: string) => `select count(*) from bis:DefinitionGroup where UserLabel = 'definitions of ${label}'`;
+
+      count(query("blueberries"), 4);
+      count(query("strawberries"), 1);
+      count(query("raspberries"), 1);
+    });
   });
 });


### PR DESCRIPTION
This PR (ref. ADO# [1461917](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/1461917)) is a follow-up to a previous fix related to updating of a new child element.  At the time of the original fix, it was observed that the code makes a determination whether the children have ids or don't have ids.  Among a collection of results, it checked only the first element to make this determination.  Since the test case concerned a new child element which didn't have an id (nor would one expect it to), the question was raised, what would happen if this element (new with no id), was prepended to the list i.e. was first?  For consistency, the new element should follow the same code path regardless of whether it appeared first or last in the list.

**Checking only the first element in the list.**  

Not wanting to add another O(n) loop over each child in the list, I repurposed a loop over all the elements that was in the code already.  Rather than simply check for whether or not the element has an Id, I check for missing Id meaning that for new elements, we don't expect an id and therefore it is NOT missing an Id.

**The bottom half of the method, idsOk = false case.**

I don't know what condition caused this code to be written, but, apparently the original author encountered a use case in which changed elements did not have ids.  There were no tests for this condition - now there are, but, more on that in a bit.  Secondly, this block of code calls updateResultInIModelForOneElement for each existing child, but, throws an error if there's no id so it is unclear how this could have ever worked.  I had to guess at the intent of this code, so, I arbitrarily copied the ids from the existing elements to the ones from the synch results.  Lastly, the code in general ignored the ItemState of the SyncResults.  Now it only attempts to update items with state "changed" and insert items with state "new" OR "changed" if there was a surplus of changed elements vs existing elements.

**New Standalone tests**

Lastly, I added six new passing tests which test both the idsOk=false and true cases.

```
      √ update modified ..., larger ... but w/ new child element first in list
spec.js:76
      √ update modified ..., larger ... but w/ one new child elements and no id
spec.js:76
      √ update modified ..., larger ... and w/ existing child elements but all missing ids
spec.js:76
      √ update modified ..., larger ... but w/ existing child elements and several new elements interspersed all missing ids
spec.js:76
      √ update modified ..., larger ... but w/ existing child elements and several new elements interspersed w Ids
spec.js:76
      √ update modified ..., larger ... but w/ more unchanged child elements than existing (some need to be inserted as new)
```