### PR TITLE
Add doc tags to extract source for write a connector documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ node.exe
 manifest.itsyn.yml
 
 # documentation
-documentation/file.json
-documentation/index.ts
+documentation/
 
 .configStore/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,10 @@ stages:
           npm run documentation
         displayName: 'npm install and build documentation'
 
+      - script: |
+          npm run extract
+        displayName: 'extract code snippets'
+
       - task: CopyFiles@2
         displayName: 'Copy generated docs to: $(Build.StagingDirectory)/docs/'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,8 +207,7 @@ stages:
       - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core
         parameters:
           checkout: itwinjs-core
-          branches: jchick-connector-doc-new-overrides
-          useCurrentConnectorFrameworkDocsArtifact: false
+          useCurrentConnectorFrameworkDocsArtifact: true
 
 - stage: Tag_Docs
   dependsOn: Validate_Docs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,8 @@ stages:
       - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core
         parameters:
           checkout: itwinjs-core
-          useCurrentConnectorFrameworkDocsArtifact: true
+          branches: jchick-connector-doc-new-overrides
+          useCurrentConnectorFrameworkDocsArtifact: false
 
 - stage: Tag_Docs
   dependsOn: Validate_Docs

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:change-set-group":"npm run build && nyc mocha --grep change-set-group",
     "test:interspersed":"npm run build && nyc mocha --grep interspersed",
     "test:connector": "node lib/test/TestConnector/Main.js test/assets/TestArgs.json",
-    "documentation": "cross-env RUSHSTACK_FILE_ERROR_BASE_FOLDER=$npm_config_local_prefix betools docs --source=./src --out=./documentation --json=./documentation/file.json --tsIndexFile=./connector-framework.ts --onlyJson"
+    "documentation": "cross-env RUSHSTACK_FILE_ERROR_BASE_FOLDER=$npm_config_local_prefix betools docs --source=./src --out=./documentation --json=./documentation/file.json --tsIndexFile=./connector-framework.ts --onlyJson",
+    "extract": "betools extract --fileExt=ts --extractFrom=./src/ --recursive --out=./documentation/extract"
   },
   "keywords": [
     "Bentley",

--- a/src/BaseConnector.ts
+++ b/src/BaseConnector.ts
@@ -92,11 +92,14 @@ export abstract class BaseConnector {
    * In the case of #2, it is up to the connector to supply the jobSubject name.
    * See [Channels]($docs/learning/backend/Channel) for an explanation of the concept of channels.
    */
+
+  // __PUBLISH_EXTRACT_START__ BaseConnector-DeletionDetectionParams.cf-code
   public getDeletionDetectionParams(): DeletionDetectionParams {
     // default to channel based deletion detection
     const ddp = {fileBased: false, scopeToPartition : false};
     return ddp;
   }
+  // __PUBLISH_EXTRACT_END__
 
   /**
    * Returns boolean flag to toggle deletion. Defaults to true where elements not marked by onElementSeen
@@ -112,20 +115,24 @@ export abstract class BaseConnector {
     return `${this.getConnectorName()}:${sourcePath}`;
   }
 
+  // __PUBLISH_EXTRACT_START__ BaseConnector-getChannelKey.cf-code
   // override this method in the derived connector class if using not shared channel
   public getChannelKey(): string {
     return ChannelControl.sharedChannelName;
   }
+  // __PUBLISH_EXTRACT_END__
 
   // override this method to create a single change set group with each connector run
   public shouldCreateChangeSetGroup(): boolean {
     return false;
   }
 
+  // __PUBLISH_EXTRACT_START__ BaseConnector-getChangeSetGroupDescription.cf-code
   // override this method to provide a custom description for the change set group
   public getChangeSetGroupDescription(): string {
     return this.getConnectorName();
   }
+  // __PUBLISH_EXTRACT_END__
 
   /** Overridable function that must me implemented when the flag shouldUnmapSource is set to true. This method is used to unmap an existing source file in the iModel */
   public async unmapSource(source: string): Promise<void> {

--- a/src/ConnectorRunner.ts
+++ b/src/ConnectorRunner.ts
@@ -79,7 +79,7 @@ export class ConnectorRunner {
     if (!json.version || json.version !== supportedVersion)
       throw new Error(`Arg file has invalid version ${json.version}. Supported version is ${supportedVersion}.`);
 
-    // __PUBLISH_EXTRACT_START__ ConnectorRunner-constructor.example-code
+    // __PUBLISH_EXTRACT_START__ ConnectorRunner-constructor.cf-code
     if (!(json.jobArgs))
       throw new Error("jobArgs is not defined");
     const jobArgs = new JobArgs(json.jobArgs);
@@ -227,6 +227,7 @@ export class ConnectorRunner {
       "Write job subject and definitions.",
     );
 
+    // __PUBLISH_EXTRACT_START__ ConnectorRunner-shouldUnmapSource.cf-code
     if(this.jobArgs.shouldUnmapSource) {
       Logger.logInfo(LoggerCategories.Framework, "Unmapping source data...");
       await this.doInRepositoryChannel(
@@ -238,6 +239,7 @@ export class ConnectorRunner {
       );
       return;
     }
+    // __PUBLISH_EXTRACT_END__
 
     Logger.logInfo(LoggerCategories.Framework, "Synchronizing...");
     await this.doInConnectorChannel(jobSubject.id,

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -192,15 +192,19 @@ function sourceItemHasScopeAndKind(item: SourceItem): item is ItemWithScopeAndKi
  * external source aspects scope to the physical partition for example.  The test connector in this repository
  * incorrectly set the external source aspects this way and it is likely other connectors followed this example.
 */
+
+// __PUBLISH_EXTRACT_START__ Syncronizer-DeletionDetectionParams.connector-framework-code
 export interface DeletionDetectionParams {
   /** true for file based (recommended for new connectors)
-   * false for channel based i.e. under JobSubject */
+     * false for channel based i.e. under JobSubject */
   fileBased: boolean;
   /** false is recommended, but, true is required for legacy connectors that create
-   * external source aspects that scope to a physical partition instead of repository
-   *  links ingored for channel based deletion detection */
+     * external source aspects that scope to a physical partition instead of repository
+     *  links ingored for channel based deletion detection */
   scopeToPartition: boolean;
 }
+
+// __PUBLISH_EXTRACT_END__
 
 /** Helper class for interacting with the iModelDb during synchronization.
  * @beta

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -193,7 +193,7 @@ function sourceItemHasScopeAndKind(item: SourceItem): item is ItemWithScopeAndKi
  * incorrectly set the external source aspects this way and it is likely other connectors followed this example.
 */
 
-// __PUBLISH_EXTRACT_START__ Syncronizer-DeletionDetectionParams.connector-framework-code
+// __PUBLISH_EXTRACT_START__ Syncronizer-DeletionDetectionParams.cf-code
 export interface DeletionDetectionParams {
   /** true for file based (recommended for new connectors)
      * false for channel based i.e. under JobSubject */
@@ -245,7 +245,7 @@ export class Synchronizer {
     return this._jobSubjectId;
   }
 
-  // __PUBLISH_EXTRACT_START__ Sychronizer-getOrCreateExternalSource.example-code
+  // __PUBLISH_EXTRACT_START__ Sychronizer-getOrCreateExternalSource.cf-code
   private getOrCreateExternalSource(repositoryLinkId: Id64String, modelId: Id64String): Id64String {
     const xse = this.getExternalSourceElementByLinkId(repositoryLinkId);
     if (xse !== undefined) {
@@ -275,7 +275,7 @@ export class Synchronizer {
    * @see [[SourceItem]] for an explanation of how an entity from an external source is tracked in relation to the RepositoryLink.
    */
 
-  // __PUBLISH_EXTRACT_START__ Synchronizer-recordDocument.example-code
+  // __PUBLISH_EXTRACT_START__ Synchronizer-recordDocument.cf-code
   public recordDocument(sourceDocument: SourceDocument): RecordDocumentResults {
     const code = RepositoryLink.createCode(this.imodel, IModel.repositoryModelId, sourceDocument.docid);
 
@@ -305,7 +305,7 @@ export class Synchronizer {
       source: "", // see below
     } as RecordDocumentResults;
 
-    // __PUBLISH_EXTRACT_START__ Synchronizer-detectChanges.example-code
+    // __PUBLISH_EXTRACT_START__ Synchronizer-detectChanges.cf-code
     const changeResults = this.detectChanges(sourceItem);
     if (Id64.isValidId64(repositoryLink.id) && changeResults.state === ItemState.New) {
       const error = `A RepositoryLink element with code=${repositoryLink.code} and id=${repositoryLink.id} already exists in the bim file.
@@ -318,7 +318,7 @@ export class Synchronizer {
     results.preChangeAspect = changeResults.existingExternalSourceAspect;
     // __PUBLISH_EXTRACT_END__
 
-    // __PUBLISH_EXTRACT_START__ Synchronizer-onElementsSeen.example-code
+    // __PUBLISH_EXTRACT_START__ Synchronizer-onElementsSeen.cf-code
     if (changeResults.state === ItemState.Unchanged) {
       assert(changeResults.id !== undefined);
       results.elementProps.id = changeResults.id;
@@ -333,7 +333,7 @@ export class Synchronizer {
     }
     // __PUBLISH_EXTRACT_END__
 
-    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.example-code
+    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.cf-code
     // Changed or New
     const status = this.updateIModel(results, sourceItem);
 
@@ -450,7 +450,7 @@ export class Synchronizer {
       return status;
     }
 
-    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.example-code
+    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.cf-code
     let aspectId: Id64String | undefined;
     if (sourceItem.id !== "") {
       const xsa = ExternalSourceAspect.findAllBySource(this.imodel, sourceItem.scope, sourceItem.kind, sourceItem.id);

--- a/test/TestConnector/ChangeSetGroupTestConnector.ts
+++ b/test/TestConnector/ChangeSetGroupTestConnector.ts
@@ -2,9 +2,11 @@ import TestConnector from "./TestConnector";
 
 export default class ChangeSetGroupTestConnector extends TestConnector {
 
+  // __PUBLISH_EXTRACT_START__ CSGTestConnector-shouldCreateChangeSetGroup.cf-code
   public override shouldCreateChangeSetGroup(): boolean {
     return true;
   }
+  // __PUBLISH_EXTRACT_END__
 
   public static override async create(): Promise<TestConnector> {
     return new ChangeSetGroupTestConnector();

--- a/test/TestConnector/NonSharedChannelKeyTestConnector.ts
+++ b/test/TestConnector/NonSharedChannelKeyTestConnector.ts
@@ -2,9 +2,11 @@ import TestConnector from "./TestConnector";
 
 export default class NonSharedChannelKeyTestConnector extends TestConnector {
 
+  // __PUBLISH_EXTRACT_START__ NSCKTestConnector-getChannelKey.cf-code
   public override getChannelKey(): string {
     return "TestConnectorChannel";
   }
+  // __PUBLISH_EXTRACT_END__
 
   public static override async create(): Promise<TestConnector> {
     return new NonSharedChannelKeyTestConnector();

--- a/test/TestConnector/TestConnector.ts
+++ b/test/TestConnector/TestConnector.ts
@@ -30,7 +30,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { LoggerCategories } from "../../src/LoggerCategory";
 
-// __PUBLISH_EXTRACT_START__ TestConnector-extendsBaseConnector.example-code
+// __PUBLISH_EXTRACT_START__ TestConnector-extendsBaseConnector.cf-code
 export default class TestConnector extends BaseConnector {
 // __PUBLISH_EXTRACT_END__
   // _data is the contents of the external source read into memory
@@ -54,11 +54,12 @@ export default class TestConnector extends BaseConnector {
     return ddp;
   }
 
+  // __PUBLISH_EXTRACT_START__ TestConnector-getDeletionDetectionParams.cf-code
   public override getDeletionDetectionParams(): DeletionDetectionParams {
-    // to avoid legacy channel based deleted element detection, override this method and set fileBased to true
-
+  // to avoid legacy channel based deleted element detection, override this method and set fileBased to true
     return this.getDDParamsFromEnv();
   }
+  // __PUBLISH_EXTRACT_END__
 
   public static override async create(): Promise<TestConnector> {
     return new TestConnector();
@@ -70,7 +71,7 @@ export default class TestConnector extends BaseConnector {
     return this._repositoryLinkId;
   }
 
-  // __PUBLISH_EXTRACT_START__ TestConnector-initializeJob.example-code
+  // __PUBLISH_EXTRACT_START__ TestConnector-initializeJob.cf-code
   public async initializeJob(): Promise<void> {
     if (ItemState.New === this._sourceDataState) {
       this.createGroupModel();
@@ -81,7 +82,7 @@ export default class TestConnector extends BaseConnector {
 
   // __PUBLISH_EXTRACT_END__
 
-  // __PUBLISH_EXTRACT_START__ TestConnector-openSourceData.example-code
+  // __PUBLISH_EXTRACT_START__ TestConnector-openSourceData.cf-code
   public async openSourceData(sourcePath: string): Promise<void> {
     // ignore the passed in source and open the test file
     const json = fs.readFileSync(sourcePath, "utf8");
@@ -97,7 +98,7 @@ export default class TestConnector extends BaseConnector {
   }
   // __PUBLISH_EXTRACT_END__
 
-  // __PUBLISH_EXTRACT_START__ TestConnector-importDomainSchema.example-code
+  // __PUBLISH_EXTRACT_START__ TestConnector-importDomainSchema.cf-code
   public async importDomainSchema(_requestContext: AccessToken): Promise<any> {
 
     if (this._sourceDataState === ItemState.Unchanged) {
@@ -124,7 +125,7 @@ export default class TestConnector extends BaseConnector {
       return;
   }
 
-  // __PUBLISH_EXTRACT_START__ TestConnector-importDefinitions.example-code
+  // __PUBLISH_EXTRACT_START__ TestConnector-importDefinitions.cf-code
 
   // importDefinitions is for definitions that are written to shared models such as DictionaryModel
   public async importDefinitions(): Promise<any> {
@@ -135,7 +136,7 @@ export default class TestConnector extends BaseConnector {
   }
   // __PUBLISH_EXTRACT_END__
 
-  // __PUBLISH_EXTRACT_START__ TestConnector-updateExistingData.example-code
+  // __PUBLISH_EXTRACT_START__ TestConnector-updateExistingData.cf-code
   public async updateExistingData() {
     const groupModelId = this.queryGroupModel();
     const physicalModelId = this.queryPhysicalModel();
@@ -167,18 +168,16 @@ export default class TestConnector extends BaseConnector {
   }
   // __PUBLISH_EXTRACT_END__
 
-  // public override getChannelKey (): string {
-  //   return "TestConnectorChannel";
-  // }
-
+  // __PUBLISH_EXTRACT_START__ TestConnector-unmapSource.cf-code
   public override async unmapSource(source: string) {
     Logger.logInfo(LoggerCategories.Framework, `Unmapping ${source}`);
     deleteElementTree(this.synchronizer.imodel, this.jobSubject.id);
-    this.synchronizer.imodel.elements.deleteElement(this.repositoryLinkId);      
+    this.synchronizer.imodel.elements.deleteElement(this.repositoryLinkId);
     // bf: ADO# 1387737 - Also delete the ExternalSource
     if (this._externalSourceId !== undefined)
       this.synchronizer.imodel.elements.deleteElement(this._externalSourceId);
   }
+  // __PUBLISH_EXTRACT_END__
 
   public getApplicationVersion(): string {
     return "1.0.0.0";

--- a/test/integration/ConnectorRunner.test.ts
+++ b/test/integration/ConnectorRunner.test.ts
@@ -79,7 +79,7 @@ describe("iTwin Connector Fwk (#integration)", () => {
 
   async function runConnector(jobArgs: JobArgs, hubArgs: HubArgs, skipVerification?: boolean) {
     const runner = new ConnectorRunner(jobArgs, hubArgs);
-    // __PUBLISH_EXTRACT_START__ ConnectorRunnerTest.run.example-code
+    // __PUBLISH_EXTRACT_START__ ConnectorRunnerTest.run.cf-code
     const status = await runner.run(testConnector);
     // __PUBLISH_EXTRACT_END_
 

--- a/test/standalone/ConnectorRunnerWithHubMock.test.ts
+++ b/test/standalone/ConnectorRunnerWithHubMock.test.ts
@@ -28,8 +28,9 @@ async function openBriefcase(hubArgs: HubArgs) {
   return db;
 }
 
+// __PUBLISH_EXTRACT_START__ CRWHMTest-FileBaseDeletionDetection.cf-code
 describe("iTwin Connector Fwk (#standalone) - file-based deletion detection", () => {
-
+// __PUBLISH_EXTRACT_END__
   let jobArgs: JobArgs;
   let hubArgs: HubArgs;
 

--- a/test/standalone/LegacyDeletionDetection.test.ts
+++ b/test/standalone/LegacyDeletionDetection.test.ts
@@ -28,7 +28,9 @@ async function openBriefcase(hubArgs: HubArgs) {
   return db;
 }
 
+// __PUBLISH_EXTRACT_START__ CRWHMTest-LegacyChannelBasedDeletionDetection.cf-code
 describe("iTwin Connector Fwk (#standalone) - Legacy Channel Based Deletion Detection", () => {
+  // __PUBLISH_EXTRACT_END__
 
   let jobArgs: JobArgs;
   let hubArgs: HubArgs;


### PR DESCRIPTION
In addition to adding new tags, we rename existing ones for consistency and to distinguish them from the static snippets in the monorepo.  We also added a new command to extract the source and run that command from the pipeline.

[ADO# 1485374](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/1485374) 
[ADO# 1486364](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/1486364) 
[ADO# 1002486](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/1002486) 

